### PR TITLE
add numpy to the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ specification that are not yet tested here.
 
 To run the tests, first install the testing dependencies
 
-    pip install pytest hypothesis
+    pip install pytest hypothesis numpy
 
 or
 
-    conda install pytest hypothesis
+    conda install pytest hypothesis numpy
 
 as well as the array libraries that you want to test. To run the tests, you
 need to set the array library that is to be tested. There are two ways to do


### PR DESCRIPTION
The test suite depends on `numpy` since we import 

https://github.com/data-apis/array-api-tests/blob/b47e667af1f216572862bb23c8b1d5ed2e9f0a3a/array_api_tests/hypothesis_helpers.py#L9

which in turn [imports `numpy` unconditionally](https://github.com/HypothesisWorks/hypothesis/blob/a00f986c5be7890312235610ab694c97501f5a81/hypothesis-python/src/hypothesis/extra/numpy.py#L20). Thus, we should add it to the installation instructions.

