### PR TITLE
all -> array_module.all

### DIFF
--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -64,7 +64,7 @@ def sanity_check(x1, x2):
 @given(numeric_scalars)
 def test_abs(x):
     a = _array_module.abs(x)
-    assert all(logical_not(negative_mathematical_sign(a))), "abs(x) did not have positive sign"
+    assert _array_module.all(logical_not(negative_mathematical_sign(a))), "abs(x) did not have positive sign"
     less_zero = negative_mathematical_sign(x)
     negx = negative(x)
     # abs(x) = -x for x < 0


### PR DESCRIPTION
The builtin `all` requires the object to be iterable, which 0d arrays are usually not.

```python
import numpy as np

all(np.array(True))
```

```
TypeError: iteration over a 0-d array
```