### PR TITLE
Implement `test_*_like` tests

### DIFF
--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -51,9 +51,6 @@ jobs:
             "array_api_tests/test_signatures.py::test_function_positional_args[__index__]",
             "array_api_tests/test_signatures.py::test_function_keyword_only_args[prod]",
             "array_api_tests/test_signatures.py::test_function_keyword_only_args[sum]",
-
-            # https://github.com/data-apis/array-api-tests/pull/18#discussion_r715047213
-            "array_api_tests/test_creation_functions.py::test_full_like"
         )
 
         def pytest_collection_modifyitems(config, items):

--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -52,6 +52,8 @@ jobs:
             "array_api_tests/test_signatures.py::test_function_keyword_only_args[prod]",
             "array_api_tests/test_signatures.py::test_function_keyword_only_args[sum]",
 
+            # https://github.com/data-apis/array-api-tests/pull/18#discussion_r715047213
+            "array_api_tests/test_creation_functions.py::test_full_like"
         )
 
         def pytest_collection_modifyitems(config, items):

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -3,8 +3,9 @@ from operator import mul
 from math import sqrt
 
 from hypothesis.strategies import (lists, integers, builds, sampled_from,
-                                   shared, floats, just, composite, one_of,
-                                   none, booleans)
+                                   shared, tuples as hypotheses_tuples,
+                                   floats, just, composite, one_of, none,
+                                   booleans, SearchStrategy)
 from hypothesis.extra.numpy import mutually_broadcastable_shapes
 from hypothesis.extra.array_api import make_strategies_namespace
 from hypothesis import assume
@@ -70,6 +71,8 @@ def make_dtype_pairs():
     return dtype_pairs
 
 def promotable_dtypes(dtype):
+    if isinstance(dtype, SearchStrategy):
+        return dtype.flatmap(promotable_dtypes)
     dtype_pairs = make_dtype_pairs()
     dtypes = [j for i, j in dtype_pairs if i == dtype]
     return sampled_from(dtypes)

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -243,3 +243,9 @@ def multiaxis_indices(draw, shapes):
         extra = draw(lists(one_of(integer_indices(sizes), slices(sizes)), min_size=0, max_size=3))
         res += extra
     return tuple(res)
+
+
+shared_optional_promotable_dtypes = one_of(
+    none(),
+    promotable_dtypes(shared_dtypes),
+)

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -242,9 +242,3 @@ def multiaxis_indices(draw, shapes):
         extra = draw(lists(one_of(integer_indices(sizes), slices(sizes)), min_size=0, max_size=3))
         res += extra
     return tuple(res)
-
-
-shared_optional_promotable_dtypes = one_of(
-    none(),
-    promotable_dtypes(shared_dtypes),
-)

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -2,11 +2,11 @@ from functools import reduce
 from operator import mul
 from math import sqrt
 
+from hypothesis import assume
 from hypothesis.strategies import (lists, integers, sampled_from,
                                    shared, floats, just, composite, one_of,
                                    none, booleans)
 from hypothesis.extra.array_api import make_strategies_namespace
-from hypothesis import assume
 
 from .pytest_helpers import nargs
 from .array_helpers import (dtype_ranges, integer_dtype_objects,

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -242,3 +242,13 @@ def multiaxis_indices(draw, shapes):
         extra = draw(lists(one_of(integer_indices(sizes), slices(sizes)), min_size=0, max_size=3))
         res += extra
     return tuple(res)
+
+
+shared_arrays1 = xps.arrays(
+    dtype=shared_dtypes,
+    shape=shared(two_mutually_broadcastable_shapes, key="shape_pair").map(lambda pair: pair[0]),
+)
+shared_arrays2 = xps.arrays(
+    dtype=promotable_dtypes(shared_dtypes),
+    shape=shared(two_mutually_broadcastable_shapes, key="shape_pair").map(lambda pair: pair[1]),
+)

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -130,7 +130,10 @@ sizes = integers(0, MAX_ARRAY_SIZE)
 sqrt_sizes = integers(0, SQRT_MAX_ARRAY_SIZE)
 
 # TODO: Generate general arrays here, rather than just scalars.
-numeric_arrays = builds(full, just((1,)), floats())
+numeric_arrays = xps.arrays(
+    dtype=shared(xps.floating_dtypes(), key='dtypes'),
+    shape=shared(xps.array_shapes(), key='shapes'),
+)
 
 @composite
 def scalars(draw, dtypes, finite=False):

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -2,10 +2,9 @@ from functools import reduce
 from operator import mul
 from math import sqrt
 
-from hypothesis.strategies import (lists, integers, builds, sampled_from,
-                                   shared, tuples as hypotheses_tuples,
-                                   floats, just, composite, one_of, none,
-                                   booleans, SearchStrategy)
+from hypothesis.strategies import (lists, integers, sampled_from,
+                                   shared, floats, just, composite, one_of,
+                                   none, booleans, SearchStrategy)
 from hypothesis.extra.array_api import make_strategies_namespace
 from hypothesis import assume
 

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -54,7 +54,7 @@ shared_dtypes = shared(dtypes, key="dtype")
 # should remove the composite wrapper, just returning sampled_from(dtype_pairs)
 # instead of drawing from it.
 @composite
-def mutually_promotable_dtype_pairs(draw, dtype_objects=dtype_objects):
+def mutually_promotable_dtypes(draw, dtype_objects=dtype_objects):
     from .test_type_promotion import dtype_mapping, promotion_table
     # sort for shrinking (sampled_from shrinks to the earlier elements in the
     # list). Give pairs of the same dtypes first, then smaller dtypes,
@@ -76,7 +76,7 @@ def mutually_promotable_dtype_pairs(draw, dtype_objects=dtype_objects):
     return draw(sampled_from(dtype_pairs))
 
 shared_mutually_promotable_dtype_pairs = shared(
-    mutually_promotable_dtype_pairs(), key="mutually_promotable_dtype_pair"
+    mutually_promotable_dtypes(), key="mutually_promotable_dtype_pair"
 )
 
 # shared() allows us to draw either the function or the function name and they

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -6,6 +6,7 @@ from hypothesis.strategies import (lists, integers, builds, sampled_from,
                                    shared, floats, just, composite, one_of,
                                    none, booleans)
 from hypothesis.extra.numpy import mutually_broadcastable_shapes
+from hypothesis.extra.array_api import make_strategies_namespace
 from hypothesis import assume
 
 from .pytest_helpers import nargs
@@ -15,8 +16,12 @@ from .array_helpers import (dtype_ranges, integer_dtype_objects,
                             integer_or_boolean_dtype_objects, dtype_objects)
 from ._array_module import full, float32, float64, bool as bool_dtype, _UndefinedStub
 from . import _array_module
+from ._array_module import mod as xp
 
 from .function_stubs import elementwise_functions
+
+
+xps = make_strategies_namespace(xp)
 
 
 # Set this to True to not fail tests just because a dtype isn't implemented.

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -251,3 +251,12 @@ shared_arrays2 = xps.arrays(
     dtype=shared_mutually_promotable_dtype_pairs.map(lambda pair: pair[1]),
     shape=shared(two_mutually_broadcastable_shapes, key="shape_pair").map(lambda pair: pair[1]),
 )
+
+
+@composite
+def kwargs(draw, **kw):
+    result = {}
+    for k, strat in kw.items():
+        if draw(booleans()):
+            result[k] = draw(strat)
+    return result

--- a/array_api_tests/meta_tests/test_hypothesis_helpers.py
+++ b/array_api_tests/meta_tests/test_hypothesis_helpers.py
@@ -11,27 +11,19 @@ UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dtype_objects)
 pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
 
 
-def test_promotable_dtypes():
-    dtypes = set()
-    @given(promotable_dtypes(xp.uint16))
-    def run(dtype):
-        dtypes.add(dtype)
-    run()
-    assert dtypes == {
+@given(promotable_dtypes(xp.uint16))
+def test_promotable_dtypes(dtype):
+    assert dtype in (
         xp.uint8, xp.uint16, xp.uint32, xp.uint64, xp.int8, xp.int16, xp.int32, xp.int64
-    }
+    )
 
 
-def test_mutually_promotable_dtype_pairs():
-    pairs = set()
-    @given(mutually_promotable_dtype_pairs([xp.float32, xp.float64]))
-    def run(pair):
-        pairs.add(pair)
-    run()
-    assert pairs == {
+@given(mutually_promotable_dtype_pairs([xp.float32, xp.float64]))
+def test_mutually_promotable_dtype_pairs(pairs):
+    assert pairs in (
         (xp.float32, xp.float32),
         (xp.float32, xp.float64),
         (xp.float64, xp.float32),
         (xp.float64, xp.float64),
-    }
+    )
 

--- a/array_api_tests/meta_tests/test_hypothesis_helpers.py
+++ b/array_api_tests/meta_tests/test_hypothesis_helpers.py
@@ -1,7 +1,7 @@
 from math import prod
 
 import pytest
-from hypothesis import given, strategies as st, assume
+from hypothesis import given, strategies as st
 
 from .. import _array_module as xp
 from .._array_module import _UndefinedStub
@@ -70,4 +70,3 @@ def test_kwargs():
     c_results = [kw for kw in results if "c" in kw]
     assert len(c_results) > 0
     assert all(isinstance(kw["c"], str) for kw in c_results)
-

--- a/array_api_tests/meta_tests/test_hypothesis_helpers.py
+++ b/array_api_tests/meta_tests/test_hypothesis_helpers.py
@@ -8,19 +8,11 @@ from .._array_module import _UndefinedStub
 from ..array_helpers import dtype_objects
 from ..hypothesis_helpers import (MAX_ARRAY_SIZE,
                                   mutually_promotable_dtype_pairs,
-                                  promotable_dtypes, shapes,
-                                  two_broadcastable_shapes,
+                                  shapes, two_broadcastable_shapes,
                                   two_mutually_broadcastable_shapes)
 
 UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dtype_objects)
 pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
-
-
-@given(promotable_dtypes(xp.uint16))
-def test_promotable_dtypes(dtype):
-    assert dtype in (
-        xp.uint8, xp.uint16, xp.uint32, xp.uint64, xp.int8, xp.int16, xp.int32, xp.int64
-    )
 
 
 @given(mutually_promotable_dtype_pairs([xp.float32, xp.float64]))

--- a/array_api_tests/meta_tests/test_hypothesis_helpers.py
+++ b/array_api_tests/meta_tests/test_hypothesis_helpers.py
@@ -7,7 +7,7 @@ from .. import _array_module as xp
 from .._array_module import _UndefinedStub
 from ..array_helpers import dtype_objects
 from ..hypothesis_helpers import (MAX_ARRAY_SIZE,
-                                  mutually_promotable_dtype_pairs,
+                                  mutually_promotable_dtypes,
                                   shapes, two_broadcastable_shapes,
                                   two_mutually_broadcastable_shapes)
 
@@ -15,8 +15,8 @@ UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dtype_objects)
 pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
 
 
-@given(mutually_promotable_dtype_pairs([xp.float32, xp.float64]))
-def test_mutually_promotable_dtype_pairs(pairs):
+@given(mutually_promotable_dtypes([xp.float32, xp.float64]))
+def test_mutually_promotable_dtypes(pairs):
     assert pairs in (
         (xp.float32, xp.float32),
         (xp.float32, xp.float64),

--- a/array_api_tests/meta_tests/test_hypothesis_helpers.py
+++ b/array_api_tests/meta_tests/test_hypothesis_helpers.py
@@ -1,0 +1,37 @@
+import pytest
+from hypothesis import given
+
+from .. import _array_module as xp
+from .._array_module import _UndefinedStub
+from ..array_helpers import dtype_objects
+from ..hypothesis_helpers import (mutually_promotable_dtype_pairs,
+                                  promotable_dtypes)
+
+UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dtype_objects)
+pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
+
+
+def test_promotable_dtypes():
+    dtypes = set()
+    @given(promotable_dtypes(xp.uint16))
+    def run(dtype):
+        dtypes.add(dtype)
+    run()
+    assert dtypes == {
+        xp.uint8, xp.uint16, xp.uint32, xp.uint64, xp.int8, xp.int16, xp.int32, xp.int64
+    }
+
+
+def test_mutually_promotable_dtype_pairs():
+    pairs = set()
+    @given(mutually_promotable_dtype_pairs([xp.float32, xp.float64]))
+    def run(pair):
+        pairs.add(pair)
+    run()
+    assert pairs == {
+        (xp.float32, xp.float32),
+        (xp.float32, xp.float64),
+        (xp.float64, xp.float32),
+        (xp.float64, xp.float64),
+    }
+

--- a/array_api_tests/meta_tests/test_hypothesis_helpers.py
+++ b/array_api_tests/meta_tests/test_hypothesis_helpers.py
@@ -1,21 +1,18 @@
 from math import prod
 
 import pytest
-from hypothesis import given
+from hypothesis import given, strategies as st, assume
 
 from .. import _array_module as xp
 from .._array_module import _UndefinedStub
-from ..array_helpers import dtype_objects
-from ..hypothesis_helpers import (MAX_ARRAY_SIZE,
-                                  mutually_promotable_dtypes,
-                                  shapes, two_broadcastable_shapes,
-                                  two_mutually_broadcastable_shapes)
+from .. import array_helpers as ah
+from .. import hypothesis_helpers as hh
 
-UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dtype_objects)
+UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in ah.dtype_objects)
 pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
 
 
-@given(mutually_promotable_dtypes([xp.float32, xp.float64]))
+@given(hh.mutually_promotable_dtypes([xp.float32, xp.float64]))
 def test_mutually_promotable_dtypes(pairs):
     assert pairs in (
         (xp.float32, xp.float32),
@@ -29,22 +26,22 @@ def valid_shape(shape) -> bool:
     return (
         all(isinstance(side, int) for side in shape)
         and all(side >= 0 for side in shape)
-        and prod(shape) < MAX_ARRAY_SIZE
+        and prod(shape) < hh.MAX_ARRAY_SIZE
     )
 
 
-@given(shapes)
+@given(hh.shapes)
 def test_shapes(shape):
     assert valid_shape(shape)
 
 
-@given(two_mutually_broadcastable_shapes)
+@given(hh.two_mutually_broadcastable_shapes)
 def test_two_mutually_broadcastable_shapes(pair):
     for shape in pair:
         assert valid_shape(shape)
 
 
-@given(two_broadcastable_shapes())
+@given(hh.two_broadcastable_shapes())
 def test_two_broadcastable_shapes(pair):
     for shape in pair:
         assert valid_shape(shape)
@@ -52,3 +49,25 @@ def test_two_broadcastable_shapes(pair):
     from ..test_broadcasting import broadcast_shapes
 
     assert broadcast_shapes(pair[0], pair[1]) == pair[0]
+
+
+def test_kwargs():
+    results = []
+
+    @given(hh.kwargs(n=st.integers(0, 10), c=st.from_regex("[a-f]")))
+    def run(kw):
+        results.append(kw)
+
+    run()
+    assert all(isinstance(kw, dict) for kw in results)
+    for size in [0, 1, 2]:
+        assert any(len(kw) == size for kw in results)
+
+    n_results = [kw for kw in results if "n" in kw]
+    assert len(n_results) > 0
+    assert all(isinstance(kw["n"], int) for kw in n_results)
+
+    c_results = [kw for kw in results if "c" in kw]
+    assert len(c_results) > 0
+    assert all(isinstance(kw["c"], str) for kw in c_results)
+

--- a/array_api_tests/meta_tests/test_hypothesis_helpers.py
+++ b/array_api_tests/meta_tests/test_hypothesis_helpers.py
@@ -1,11 +1,16 @@
+from math import prod
+
 import pytest
 from hypothesis import given
 
 from .. import _array_module as xp
 from .._array_module import _UndefinedStub
 from ..array_helpers import dtype_objects
-from ..hypothesis_helpers import (mutually_promotable_dtype_pairs,
-                                  promotable_dtypes)
+from ..hypothesis_helpers import (MAX_ARRAY_SIZE,
+                                  mutually_promotable_dtype_pairs,
+                                  promotable_dtypes, shapes,
+                                  two_broadcastable_shapes,
+                                  two_mutually_broadcastable_shapes)
 
 UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dtype_objects)
 pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
@@ -27,3 +32,31 @@ def test_mutually_promotable_dtype_pairs(pairs):
         (xp.float64, xp.float64),
     )
 
+
+def valid_shape(shape) -> bool:
+    return (
+        all(isinstance(side, int) for side in shape)
+        and all(side >= 0 for side in shape)
+        and prod(shape) < MAX_ARRAY_SIZE
+    )
+
+
+@given(shapes)
+def test_shapes(shape):
+    assert valid_shape(shape)
+
+
+@given(two_mutually_broadcastable_shapes)
+def test_two_mutually_broadcastable_shapes(pair):
+    for shape in pair:
+        assert valid_shape(shape)
+
+
+@given(two_broadcastable_shapes())
+def test_two_broadcastable_shapes(pair):
+    for shape in pair:
+        assert valid_shape(shape)
+
+    from ..test_broadcasting import broadcast_shapes
+
+    assert broadcast_shapes(pair[0], pair[1]) == pair[0]

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -130,7 +130,6 @@ def test_full(shape, fill_value, dtype):
     else:
         assert all(equal(a, asarray(fill_value, **kwargs))), "full() array did not equal the fill value"
 
-# TODO: implement full_like (requires hypothesis arrays support)
 @given(
     a=xps.arrays(
         dtype=shared(xps.scalar_dtypes(), key='dtypes'),

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -8,7 +8,7 @@ from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
                                  scalars, xps)
 
 from hypothesis import assume, given
-from hypothesis.strategies import integers, floats, one_of, none, booleans, just, shared
+from hypothesis.strategies import integers, floats, one_of, none, booleans, just
 
 int_range = integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE)
 float_range = floats(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE,

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -84,7 +84,7 @@ def test_empty(shape, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
+    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
 )
 def test_empty_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -155,8 +155,8 @@ def test_full(shape, fill_value, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    fill_value=shared_dtypes.flatmap(promotable_dtypes).flatmap(xps.from_dtype),
-    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
+    fill_value=promotable_dtypes(shared_dtypes).flatmap(xps.from_dtype),
+    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
 )
 def test_full_like(a, fill_value, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -247,7 +247,7 @@ def test_ones(shape, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
+    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
 )
 def test_ones_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -298,7 +298,7 @@ def test_zeros(shape, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
+    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
 )
 def test_zeros_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -109,7 +109,7 @@ def test_eye(n_rows, n_cols, k, dtype):
     else:
         a = eye(n_rows, n_cols, **kwargs)
     if dtype is None:
-        assert is_float_dtype(a.dtype), "eye() should returned an array with the default floating point dtype"
+        assert is_float_dtype(a.dtype), "eye() should return an array with the default floating point dtype"
     else:
         assert a.dtype == dtype, "eye() did not produce the correct dtype"
 
@@ -209,11 +209,11 @@ def test_linspace(start, stop, num, dtype, endpoint):
     a = linspace(start, stop, num, **kwargs)
 
     if dtype is None:
-        assert is_float_dtype(a.dtype), "linspace() should returned an array with the default floating point dtype"
+        assert is_float_dtype(a.dtype), "linspace() should return an array with the default floating point dtype"
     else:
         assert a.dtype == dtype, "linspace() did not produce the correct dtype"
 
-    assert a.shape == (num,), "linspace() did not returned an array with the correct shape"
+    assert a.shape == (num,), "linspace() did not return an array with the correct shape"
 
     if endpoint in [None, True]:
         if num > 1:

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -81,18 +81,17 @@ def test_empty(shape, dtype):
 
 @given(
     a=xps.arrays(
-        dtype=shared(xps.scalar_dtypes(), key='dtypes'),
+        dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    kwargs=one_of(
-        just({}),
-        shared(xps.scalar_dtypes(), key='dtypes').map(lambda d: {'dtype': d}),
-    ),
+    dtype=one_of(none(), shared_dtypes),
 )
-def test_empty_like(a, kwargs):
+def test_empty_like(a, dtype):
+    kwargs = {} if dtype is None else {'dtype': dtype}
+
     a_like = empty_like(a, **kwargs)
 
-    if kwargs is None:
+    if dtype is None:
         # TODO: Should it actually match a.dtype?
         # assert is_float_dtype(a_like.dtype), "empty_like() should produce an array with the default floating point dtype"
         pass
@@ -153,26 +152,24 @@ def test_full(shape, fill_value, dtype):
 
 @given(
     a=xps.arrays(
-        dtype=shared(xps.scalar_dtypes(), key='dtypes'),
+        dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    fill_value=shared(xps.scalar_dtypes(), key='dtypes').flatmap(xps.from_dtype),
-    kwargs=one_of(
-        just({}),
-        shared(xps.scalar_dtypes(), key='dtypes').map(lambda d: {'dtype': d}),
-    ),
+    fill_value=shared_dtypes.flatmap(xps.from_dtype),
+    dtype=one_of(none(), shared_dtypes),
 )
-def test_full_like(a, fill_value, kwargs):
+def test_full_like(a, fill_value, dtype):
+    kwargs = {} if dtype is None else {'dtype': dtype}
+
     a_like = full_like(a, fill_value, **kwargs)
 
-    if kwargs is None:
+    if dtype is None:
         # TODO: Should it actually match a.dtype?
         pass
     else:
         assert a_like.dtype == a.dtype
 
     assert a_like.shape == a.shape, "full_like() produced an array with incorrect shape"
-
     if is_float_dtype(a_like.dtype) and isnan(asarray(fill_value)):
         assert all(isnan(a_like)), "full_like() array did not equal the fill value"
     else:
@@ -247,15 +244,13 @@ def test_ones(shape, dtype):
 
 @given(
     a=xps.arrays(
-        dtype=shared(xps.scalar_dtypes(), key='dtypes'),
+        dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    kwargs=one_of(
-        just({}),
-        shared(xps.scalar_dtypes(), key='dtypes').map(lambda d: {'dtype': d}),
-    ),
+    dtype=one_of(none(), shared_dtypes),
 )
-def test_ones_like(a, kwargs):
+def test_ones_like(a, dtype):
+    kwargs = {} if dtype is None else {'dtype': dtype}
     if kwargs is None or is_float_dtype(a.dtype):
         ONE = 1.0
     elif is_integer_dtype(a.dtype):
@@ -300,16 +295,14 @@ def test_zeros(shape, dtype):
 
 @given(
     a=xps.arrays(
-        dtype=shared(xps.scalar_dtypes(), key='dtypes'),
+        dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    kwargs=one_of(
-        just({}),
-        shared(xps.scalar_dtypes(), key='dtypes').map(lambda d: {'dtype': d}),
-    ),
+    dtype=one_of(none(), shared_dtypes),
 )
-def test_zeros_like(a, kwargs):
-    if kwargs is None or is_float_dtype(a.dtype):
+def test_zeros_like(a, dtype):
+    kwargs = {} if dtype is None else {'dtype': dtype}
+    if dtype is None or is_float_dtype(a.dtype):
         ZERO = 0.0
     elif is_integer_dtype(a.dtype):
         ZERO = 0

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -3,7 +3,7 @@ from ._array_module import (asarray, arange, ceil, empty, empty_like, eye, full,
                             zeros, zeros_like, isnan)
 from .array_helpers import (is_integer_dtype, dtype_ranges,
                             assert_exactly_equal, isintegral, is_float_dtype)
-from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
+from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE, promotable_dtypes,
                                  shapes, sizes, sqrt_sizes, shared_dtypes,
                                  scalars, xps)
 
@@ -84,7 +84,7 @@ def test_empty(shape, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    dtype=one_of(none(), shared_dtypes),
+    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
 )
 def test_empty_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -96,7 +96,7 @@ def test_empty_like(a, dtype):
         # assert is_float_dtype(a_like.dtype), "empty_like() should produce an array with the default floating point dtype"
         pass
     else:
-        assert a_like.dtype == a.dtype, "empty_like() produced an array with an incorrect dtype"
+        assert a_like.dtype == dtype, "empty_like() produced an array with an incorrect dtype"
 
     assert a_like.shape == a.shape, "empty_like() produced an array with an incorrect shape"
 
@@ -155,8 +155,8 @@ def test_full(shape, fill_value, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    fill_value=shared_dtypes.flatmap(xps.from_dtype),
-    dtype=one_of(none(), shared_dtypes),
+    fill_value=shared_dtypes.flatmap(promotable_dtypes).flatmap(xps.from_dtype),
+    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
 )
 def test_full_like(a, fill_value, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -167,13 +167,13 @@ def test_full_like(a, fill_value, dtype):
         # TODO: Should it actually match a.dtype?
         pass
     else:
-        assert a_like.dtype == a.dtype
+        assert a_like.dtype == dtype
 
     assert a_like.shape == a.shape, "full_like() produced an array with incorrect shape"
     if is_float_dtype(a_like.dtype) and isnan(asarray(fill_value)):
         assert all(isnan(a_like)), "full_like() array did not equal the fill value"
     else:
-        assert all(equal(a_like, asarray(fill_value, dtype=a.dtype))), "full_like() array did not equal the fill value"
+        assert all(equal(a_like, asarray(fill_value, dtype=a_like.dtype))), "full_like() array did not equal the fill value"
 
 
 @given(scalars(shared_dtypes, finite=True),
@@ -247,7 +247,7 @@ def test_ones(shape, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    dtype=one_of(none(), shared_dtypes),
+    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
 )
 def test_ones_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -260,11 +260,11 @@ def test_ones_like(a, dtype):
 
     a_like = ones_like(a, **kwargs)
 
-    if kwargs is None:
+    if dtype is None:
         # TODO: Should it actually match a.dtype?
         pass
     else:
-        assert a_like.dtype == a.dtype, "ones_like() produced an array with an incorrect dtype"
+        assert a_like.dtype == dtype, "ones_like() produced an array with an incorrect dtype"
 
     assert a_like.shape == a.shape, "ones_like() produced an array with an incorrect shape"
     assert all(equal(a_like, full((), ONE, dtype=a_like.dtype))), "ones_like() array did not equal 1"
@@ -298,7 +298,7 @@ def test_zeros(shape, dtype):
         dtype=shared_dtypes,
         shape=xps.array_shapes(),
     ),
-    dtype=one_of(none(), shared_dtypes),
+    dtype=one_of(none(), shared_dtypes.flatmap(promotable_dtypes)),
 )
 def test_zeros_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -311,11 +311,11 @@ def test_zeros_like(a, dtype):
 
     a_like = zeros_like(a, **kwargs)
 
-    if kwargs is None:
+    if dtype is None:
         # TODO: Should it actually match a.dtype?
         pass
     else:
-        assert a_like.dtype == a.dtype, "zeros_like() produced an array with an incorrect dtype"
+        assert a_like.dtype == dtype, "zeros_like() produced an array with an incorrect dtype"
 
     assert a_like.shape == a.shape, "zeros_like() produced an array with an incorrect shape"
     assert all(equal(a_like, full((), ZERO, dtype=a_like.dtype))), "zeros_like() array did not equal 0"

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -1,3 +1,5 @@
+import math
+
 from ._array_module import (asarray, arange, ceil, empty, empty_like, eye, full,
                             full_like, equal, all, linspace, ones, ones_like,
                             zeros, zeros_like, isnan)
@@ -157,7 +159,7 @@ def test_full(shape, fill_value, kw):
     else:
         assert out.dtype == dtype
     assert out.shape == shape,  f"{shape=}, but full() returned an array with shape {out.shape}"
-    if is_float_dtype(out.dtype) and isnan(asarray(fill_value)):
+    if is_float_dtype(out.dtype) and math.isnan(fill_value):
         assert all(isnan(out)), "full() array did not equal the fill value"
     else:
         assert all(equal(out, asarray(fill_value, dtype=dtype))), "full() array did not equal the fill value"
@@ -183,7 +185,7 @@ def test_full_like(x, fill_value, kw):
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but full_like() returned an array with dtype {out.dtype}"
     assert out.shape == x.shape, "{x.shape=}, but full_like() returned an array with shape {out.shape}"
-    if is_float_dtype(dtype) and isnan(asarray(fill_value)):
+    if is_float_dtype(dtype) and math.isnan(fill_value):
         assert all(isnan(out)), "full_like() array did not equal the fill value"
     else:
         assert all(equal(out, asarray(fill_value, dtype=dtype))), "full_like() array did not equal the fill value"

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -1,8 +1,6 @@
-from hypothesis.strategies._internal.core import sampled_from
 from ._array_module import (asarray, arange, ceil, empty, empty_like, eye, full,
                             full_like, equal, all, linspace, ones, ones_like,
                             zeros, zeros_like, isnan)
-from . import _array_module as xp
 from .array_helpers import (is_integer_dtype, dtype_ranges,
                             assert_exactly_equal, isintegral, is_float_dtype)
 from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
@@ -10,7 +8,7 @@ from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
                                  scalars, xps)
 
 from hypothesis import assume, given
-from hypothesis.strategies import integers, floats, one_of, none, booleans, just, shared, composite
+from hypothesis.strategies import integers, floats, one_of, none, booleans, just, shared
 
 
 optional_dtypes = none() | shared_dtypes
@@ -157,34 +155,19 @@ def test_full(shape, fill_value, dtype):
     else:
         assert all(equal(a, asarray(fill_value, **kwargs))), "full() array did not equal the fill value"
 
-@composite
-def fill_values(draw):
-    # If dtype has been specified, fill_value should be inferred from it
-    dtype = draw(shared_optional_dtypes)
-    # If dtype=None, fill_value can be anything - full_like should infer the dtype
-    if dtype is None:
-        dtype = draw(sampled_from([xp.bool, xp.int32, xp.float32]))
-    return draw(xps.from_dtype(dtype))
 
 @given(
     x=xps.arrays(dtype=shared_dtypes, shape=shapes),
-    fill_value=fill_values(),
+    fill_value=shared_dtypes.flatmap(xps.from_dtype),
     dtype=shared_optional_dtypes,
 )
 def test_full_like(x, fill_value, dtype):
     x_like = full_like(x, fill_value, dtype=dtype)
 
     if dtype is None:
-        if isinstance(fill_value, bool):
-            assert x_like.dtype == xp.bool, f"{fill_value=}, but full_like() did not produce a boolean array - instead was {x_like.dtype}"
-        elif isinstance(fill_value, int):
-            assert x_like.dtype in (xp.int32, xp.int64), f"{fill_value=}, but full_like() did not produce a int32 or int64 array - instead was {x_like.dtype}"
-        elif isinstance(fill_value, float):
-            assert x_like.dtype in (xp.float32, xp.float64), f"{fill_value=}, but full_like() did not produce a float32 or float64 array - instead was {x_like.dtype}"
-        else:
-            raise Exception(f"Sanity check failed, indiciating a bug in the test suite. {fill_value=} - should be a bool, int or float")
+        assert x_like.dtype == x.dtype, f"{x.dtype=}, but full_like() did not produce a {x.dtype} array - instead was {x_like.dtype}"
     else:
-        assert x_like.dtype == dtype
+        assert x_like.dtype == None, f"{dtype=}, but full_like() did not produce a {dtype} array - instead was {x_like.dtype}"
 
     assert x_like.shape == x.shape, "full_like() produced an array with incorrect shape"
     if is_float_dtype(x_like.dtype) and isnan(asarray(fill_value)):

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -11,10 +11,6 @@ from hypothesis import assume, given
 from hypothesis.strategies import integers, floats, one_of, none, booleans, just, shared, composite
 
 
-optional_dtypes = none() | shared_dtypes
-shared_optional_dtypes = shared(optional_dtypes, key="optional_dtype")
-
-
 int_range = integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE)
 float_range = floats(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE,
                      allow_nan=False)
@@ -95,7 +91,7 @@ def test_empty_like(x, kw):
         assert out.dtype == x.dtype, f"{x.dtype=!s}, but empty_like() returned an array with dtype {out.dtype}"
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but empty_like() returned an array with dtype {out.dtype}"
-    assert out.shape == x.shape, "empty_like() produced an array with an incorrect shape"
+    assert out.shape == x.shape, f"{x.shape=}, but empty_like() returned an array with shape {out.shape}"
 
 
 # TODO: Use this method for all optional arguments

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -82,7 +82,7 @@ def test_empty(shape, dtype):
 @given(
     a=xps.arrays(
         dtype=shared_dtypes,
-        shape=xps.array_shapes(),
+        shape=shapes,
     ),
     dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
 )
@@ -153,7 +153,7 @@ def test_full(shape, fill_value, dtype):
 @given(
     a=xps.arrays(
         dtype=shared_dtypes,
-        shape=xps.array_shapes(),
+        shape=shapes,
     ),
     fill_value=promotable_dtypes(shared_dtypes).flatmap(xps.from_dtype),
     dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
@@ -245,7 +245,7 @@ def test_ones(shape, dtype):
 @given(
     a=xps.arrays(
         dtype=shared_dtypes,
-        shape=xps.array_shapes(),
+        shape=shapes,
     ),
     dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
 )
@@ -296,7 +296,7 @@ def test_zeros(shape, dtype):
 @given(
     a=xps.arrays(
         dtype=shared_dtypes,
-        shape=xps.array_shapes(),
+        shape=shapes,
     ),
     dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
 )

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -5,10 +5,12 @@ from .array_helpers import (is_integer_dtype, dtype_ranges,
                             assert_exactly_equal, isintegral, is_float_dtype)
 from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE, promotable_dtypes,
                                  shapes, sizes, sqrt_sizes, shared_dtypes,
-                                 scalars, xps)
+                                 scalars, xps, shared_optional_promotable_dtypes)
 
 from hypothesis import assume, given
 from hypothesis.strategies import integers, floats, one_of, none, booleans, just
+
+
 
 int_range = integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE)
 float_range = floats(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE,
@@ -84,7 +86,7 @@ def test_empty(shape, dtype):
         dtype=shared_dtypes,
         shape=shapes,
     ),
-    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
+    dtype=shared_optional_promotable_dtypes,
 )
 def test_empty_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -156,7 +158,7 @@ def test_full(shape, fill_value, dtype):
         shape=shapes,
     ),
     fill_value=promotable_dtypes(shared_dtypes).flatmap(xps.from_dtype),
-    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
+    dtype=shared_optional_promotable_dtypes,
 )
 def test_full_like(a, fill_value, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -247,7 +249,7 @@ def test_ones(shape, dtype):
         dtype=shared_dtypes,
         shape=shapes,
     ),
-    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
+    dtype=shared_optional_promotable_dtypes,
 )
 def test_ones_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
@@ -298,7 +300,7 @@ def test_zeros(shape, dtype):
         dtype=shared_dtypes,
         shape=shapes,
     ),
-    dtype=one_of(none(), promotable_dtypes(shared_dtypes)),
+    dtype=shared_optional_promotable_dtypes,
 )
 def test_zeros_like(a, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -97,11 +97,9 @@ def test_empty_like(x, dtype):
     x_like = empty_like(x, **kwargs)
 
     if dtype is None:
-        # TODO: Should it actually match a.dtype?
-        # assert is_float_dtype(x_like.dtype), "empty_like() should produce an array with the default floating point dtype"
-        pass
+        assert x_like.dtype == x.dtype, f"{x.dtype=!s}, but empty_like() did not produce a {x.dtype} array - instead was {x_like.dtype}"
     else:
-        assert x_like.dtype == dtype, "empty_like() produced an array with an incorrect dtype"
+        assert x_like.dtype == dtype, f"{dtype=!s}, but empty_like() did not produce a {dtype} array - instead was {x_like.dtype}"
 
     assert x_like.shape == x.shape, "empty_like() produced an array with an incorrect shape"
 
@@ -165,9 +163,9 @@ def test_full_like(x, fill_value, dtype):
     x_like = full_like(x, fill_value, dtype=dtype)
 
     if dtype is None:
-        assert x_like.dtype == x.dtype, f"{x.dtype=}, but full_like() did not produce a {x.dtype} array - instead was {x_like.dtype}"
+        assert x_like.dtype == x.dtype, f"{x.dtype=!s}, but full_like() did not produce a {x.dtype} array - instead was {x_like.dtype}"
     else:
-        assert x_like.dtype == None, f"{dtype=}, but full_like() did not produce a {dtype} array - instead was {x_like.dtype}"
+        assert x_like.dtype == dtype, f"{dtype=!s}, but full_like() did not produce a {dtype} array - instead was {x_like.dtype}"
 
     assert x_like.shape == x.shape, "full_like() produced an array with incorrect shape"
     if is_float_dtype(x_like.dtype) and isnan(asarray(fill_value)):
@@ -258,10 +256,9 @@ def test_ones_like(x, dtype):
     x_like = ones_like(x, **kwargs)
 
     if dtype is None:
-        # TODO: Should it actually match a.dtype?
-        pass
+        assert x_like.dtype == x.dtype, f"{x.dtype=!s}, but ones_like() did not produce a {x.dtype} array - instead was {x_like.dtype}"
     else:
-        assert x_like.dtype == dtype, "ones_like() produced an array with an incorrect dtype"
+        assert x_like.dtype == dtype, f"{dtype=!s}, but ones_like() did not produce a {dtype} array - instead was {x_like.dtype}"
 
     assert x_like.shape == x.shape, "ones_like() produced an array with an incorrect shape"
     assert all(equal(x_like, full((), ONE, dtype=x_like.dtype))), "ones_like() array did not equal 1"
@@ -306,10 +303,9 @@ def test_zeros_like(x, dtype):
     x_like = zeros_like(x, **kwargs)
 
     if dtype is None:
-        # TODO: Should it actually match a.dtype?
-        pass
+        assert x_like.dtype == x.dtype, f"{x.dtype=!s}, but zeros_like() did not produce a {x.dtype} array - instead was {x_like.dtype}"
     else:
-        assert x_like.dtype == dtype, "zeros_like() produced an array with an incorrect dtype"
+        assert x_like.dtype == dtype, f"{dtype=!s}, but zeros_like() did not produce a {dtype} array - instead was {x_like.dtype}"
 
     assert x_like.shape == x.shape, "zeros_like() produced an array with an incorrect shape"
     assert all(equal(x_like, full((), ZERO, dtype=x_like.dtype))), "zeros_like() array did not equal 0"

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -3,13 +3,16 @@ from ._array_module import (asarray, arange, ceil, empty, empty_like, eye, full,
                             zeros, zeros_like, isnan)
 from .array_helpers import (is_integer_dtype, dtype_ranges,
                             assert_exactly_equal, isintegral, is_float_dtype)
-from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE, promotable_dtypes,
+from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
                                  shapes, sizes, sqrt_sizes, shared_dtypes,
-                                 scalars, xps, shared_optional_promotable_dtypes)
+                                 scalars, xps)
 
 from hypothesis import assume, given
 from hypothesis.strategies import integers, floats, one_of, none, booleans, just, shared, composite
 
+
+optional_dtypes = none() | shared_dtypes
+shared_optional_dtypes = shared(optional_dtypes, key="optional_dtype")
 
 
 int_range = integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE)
@@ -82,25 +85,25 @@ def test_empty(shape, dtype):
 
 
 @given(
-    a=xps.arrays(
-        dtype=shared_dtypes,
+    x=xps.arrays(
+        dtype=dtypes,
         shape=shapes,
     ),
-    dtype=shared_optional_promotable_dtypes,
+    dtype=optional_dtypes,
 )
-def test_empty_like(a, dtype):
+def test_empty_like(x, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
 
-    a_like = empty_like(a, **kwargs)
+    x_like = empty_like(x, **kwargs)
 
     if dtype is None:
         # TODO: Should it actually match a.dtype?
-        # assert is_float_dtype(a_like.dtype), "empty_like() should produce an array with the default floating point dtype"
+        # assert is_float_dtype(x_like.dtype), "empty_like() should produce an array with the default floating point dtype"
         pass
     else:
-        assert a_like.dtype == dtype, "empty_like() produced an array with an incorrect dtype"
+        assert x_like.dtype == dtype, "empty_like() produced an array with an incorrect dtype"
 
-    assert a_like.shape == a.shape, "empty_like() produced an array with an incorrect shape"
+    assert x_like.shape == x.shape, "empty_like() produced an array with an incorrect shape"
 
 
 # TODO: Use this method for all optional arguments
@@ -151,8 +154,6 @@ def test_full(shape, fill_value, dtype):
         assert all(isnan(a)), "full() array did not equal the fill value"
     else:
         assert all(equal(a, asarray(fill_value, **kwargs))), "full() array did not equal the fill value"
-
-shared_optional_dtypes = shared(none() | shared_dtypes, key="optional_dtype")
 
 @composite
 def fill_values(draw):
@@ -251,31 +252,28 @@ def test_ones(shape, dtype):
 
 
 @given(
-    a=xps.arrays(
-        dtype=shared_dtypes,
-        shape=shapes,
-    ),
-    dtype=shared_optional_promotable_dtypes,
+    x=xps.arrays(dtype=dtypes, shape=shapes),
+    dtype=optional_dtypes,
 )
-def test_ones_like(a, dtype):
+def test_ones_like(x, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
-    if kwargs is None or is_float_dtype(a.dtype):
+    if kwargs is None or is_float_dtype(x.dtype):
         ONE = 1.0
-    elif is_integer_dtype(a.dtype):
+    elif is_integer_dtype(x.dtype):
         ONE = 1
     else:
         ONE = True
 
-    a_like = ones_like(a, **kwargs)
+    x_like = ones_like(x, **kwargs)
 
     if dtype is None:
         # TODO: Should it actually match a.dtype?
         pass
     else:
-        assert a_like.dtype == dtype, "ones_like() produced an array with an incorrect dtype"
+        assert x_like.dtype == dtype, "ones_like() produced an array with an incorrect dtype"
 
-    assert a_like.shape == a.shape, "ones_like() produced an array with an incorrect shape"
-    assert all(equal(a_like, full((), ONE, dtype=a_like.dtype))), "ones_like() array did not equal 1"
+    assert x_like.shape == x.shape, "ones_like() produced an array with an incorrect shape"
+    assert all(equal(x_like, full((), ONE, dtype=x_like.dtype))), "ones_like() array did not equal 1"
 
 
 @given(shapes, one_of(none(), dtypes))
@@ -302,29 +300,26 @@ def test_zeros(shape, dtype):
 
 
 @given(
-    a=xps.arrays(
-        dtype=shared_dtypes,
-        shape=shapes,
-    ),
-    dtype=shared_optional_promotable_dtypes,
+    x=xps.arrays(dtype=dtypes, shape=shapes),
+    dtype=optional_dtypes,
 )
-def test_zeros_like(a, dtype):
+def test_zeros_like(x, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
-    if dtype is None or is_float_dtype(a.dtype):
+    if dtype is None or is_float_dtype(x.dtype):
         ZERO = 0.0
-    elif is_integer_dtype(a.dtype):
+    elif is_integer_dtype(x.dtype):
         ZERO = 0
     else:
         ZERO = False
 
-    a_like = zeros_like(a, **kwargs)
+    x_like = zeros_like(x, **kwargs)
 
     if dtype is None:
         # TODO: Should it actually match a.dtype?
         pass
     else:
-        assert a_like.dtype == dtype, "zeros_like() produced an array with an incorrect dtype"
+        assert x_like.dtype == dtype, "zeros_like() produced an array with an incorrect dtype"
 
-    assert a_like.shape == a.shape, "zeros_like() produced an array with an incorrect shape"
-    assert all(equal(a_like, full((), ZERO, dtype=a_like.dtype))), "zeros_like() array did not equal 0"
+    assert x_like.shape == x.shape, "zeros_like() produced an array with an incorrect shape"
+    assert all(equal(x_like, full((), ZERO, dtype=x_like.dtype))), "zeros_like() array did not equal 0"
 

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -1,5 +1,6 @@
-from ._array_module import (asarray, arange, ceil, empty, eye, full, full_like,
-                            equal, all, linspace, ones, zeros, isnan)
+from ._array_module import (asarray, arange, ceil, empty, empty_like, eye, full,
+                            full_like, equal, all, linspace, ones, ones_like,
+                            zeros, zeros_like, isnan)
 from .array_helpers import (is_integer_dtype, dtype_ranges,
                             assert_exactly_equal, isintegral, is_float_dtype)
 from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
@@ -77,9 +78,29 @@ def test_empty(shape, dtype):
         shape = (shape,)
     assert a.shape == shape, "empty() produced an array with an incorrect shape"
 
-# TODO: implement empty_like (requires hypothesis arrays support)
-def test_empty_like():
-    pass
+
+@given(
+    a=xps.arrays(
+        dtype=shared(xps.scalar_dtypes(), key='dtypes'),
+        shape=xps.array_shapes(),
+    ),
+    kwargs=one_of(
+        just({}),
+        shared(xps.scalar_dtypes(), key='dtypes').map(lambda d: {'dtype': d}),
+    ),
+)
+def test_empty_like(a, kwargs):
+    a_like = empty_like(a, **kwargs)
+
+    if kwargs is None:
+        # TODO: Should it actually match a.dtype?
+        # assert is_float_dtype(a_like.dtype), "empty_like() should produce an array with the default floating point dtype"
+        pass
+    else:
+        assert a_like.dtype == a.dtype, "empty_like() produced an array with an incorrect dtype"
+
+    assert a_like.shape == a.shape, "empty_like() produced an array with an incorrect shape"
+
 
 # TODO: Use this method for all optional arguments
 optional_marker = object()
@@ -145,7 +166,8 @@ def test_full_like(a, fill_value, kwargs):
     a_like = full_like(a, fill_value, **kwargs)
 
     if kwargs is None:
-        pass # TODO: Should it actually match the fill_value?
+        # TODO: Should it actually match a.dtype?
+        pass
     else:
         assert a_like.dtype == a.dtype
 
@@ -222,9 +244,36 @@ def test_ones(shape, dtype):
     assert a.shape == shape, "ones() produced an array with incorrect shape"
     assert all(equal(a, full((), ONE, **kwargs))), "ones() array did not equal 1"
 
-# TODO: implement ones_like (requires hypothesis arrays support)
-def test_ones_like():
-    pass
+
+@given(
+    a=xps.arrays(
+        dtype=shared(xps.scalar_dtypes(), key='dtypes'),
+        shape=xps.array_shapes(),
+    ),
+    kwargs=one_of(
+        just({}),
+        shared(xps.scalar_dtypes(), key='dtypes').map(lambda d: {'dtype': d}),
+    ),
+)
+def test_ones_like(a, kwargs):
+    if kwargs is None or is_float_dtype(a.dtype):
+        ONE = 1.0
+    elif is_integer_dtype(a.dtype):
+        ONE = 1
+    else:
+        ONE = True
+
+    a_like = ones_like(a, **kwargs)
+
+    if kwargs is None:
+        # TODO: Should it actually match a.dtype?
+        pass
+    else:
+        assert a_like.dtype == a.dtype, "ones_like() produced an array with an incorrect dtype"
+
+    assert a_like.shape == a.shape, "ones_like() produced an array with an incorrect shape"
+    assert all(equal(a_like, full((), ONE, dtype=a_like.dtype))), "ones_like() array did not equal 1"
+
 
 @given(shapes, one_of(none(), dtypes))
 def test_zeros(shape, dtype):
@@ -248,6 +297,33 @@ def test_zeros(shape, dtype):
     assert a.shape == shape, "zeros() produced an array with incorrect shape"
     assert all(equal(a, full((), ZERO, **kwargs))), "zeros() array did not equal 0"
 
-# TODO: implement zeros_like (requires hypothesis arrays support)
-def test_zeros_like():
-    pass
+
+@given(
+    a=xps.arrays(
+        dtype=shared(xps.scalar_dtypes(), key='dtypes'),
+        shape=xps.array_shapes(),
+    ),
+    kwargs=one_of(
+        just({}),
+        shared(xps.scalar_dtypes(), key='dtypes').map(lambda d: {'dtype': d}),
+    ),
+)
+def test_zeros_like(a, kwargs):
+    if kwargs is None or is_float_dtype(a.dtype):
+        ZERO = 0.0
+    elif is_integer_dtype(a.dtype):
+        ZERO = 0
+    else:
+        ZERO = False
+
+    a_like = zeros_like(a, **kwargs)
+
+    if kwargs is None:
+        # TODO: Should it actually match a.dtype?
+        pass
+    else:
+        assert a_like.dtype == a.dtype, "zeros_like() produced an array with an incorrect dtype"
+
+    assert a_like.shape == a.shape, "zeros_like() produced an array with an incorrect shape"
+    assert all(equal(a_like, full((), ZERO, dtype=a_like.dtype))), "zeros_like() array did not equal 0"
+

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -15,7 +15,7 @@ arrays of any shape, using masking patterns (similar to the tests in special_cas
 """
 
 from hypothesis import given, assume
-from hypothesis.strategies import composite, just
+from hypothesis.strategies import composite, just, shared
 
 import math
 
@@ -26,7 +26,7 @@ from .hypothesis_helpers import (integer_dtype_objects,
                                  boolean_dtype_objects, floating_dtypes,
                                  numeric_dtypes, integer_or_boolean_dtypes,
                                  boolean_dtypes, mutually_promotable_dtypes,
-                                 array_scalars)
+                                 array_scalars, xps)
 from .array_helpers import (assert_exactly_equal, negative,
                             positive_mathematical_sign,
                             negative_mathematical_sign, logical_not,
@@ -374,9 +374,17 @@ def test_divide(args):
     # could test that this does implement IEEE 754 division, but we don't yet
     # have those sorts in general for this module.
 
-@given(two_any_dtypes.flatmap(lambda i: two_array_scalars(*i)))
-def test_equal(args):
-    x1, x2 = args
+
+
+@given(
+    x1=shared(
+        xps.arrays(dtype=xps.scalar_dtypes(), shape=xps.array_shapes()), key='arrays'
+    ),
+    x2=shared(
+        xps.arrays(dtype=xps.scalar_dtypes(), shape=xps.array_shapes()), key='arrays'
+    ),
+)
+def test_equal(x1, x2):
     sanity_check(x1, x2)
     a = _array_module.equal(x1, x2)
     # NOTE: assert_exactly_equal() itself uses equal(), so we must be careful

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -25,7 +25,7 @@ from .hypothesis_helpers import (integer_dtype_objects,
                                  integer_or_boolean_dtype_objects,
                                  boolean_dtype_objects, floating_dtypes,
                                  numeric_dtypes, integer_or_boolean_dtypes,
-                                 boolean_dtypes, mutually_promotable_dtypes,
+                                 boolean_dtypes, mutually_promotable_dtype_pairs,
                                  array_scalars, xps)
 from .array_helpers import (assert_exactly_equal, negative,
                             positive_mathematical_sign,
@@ -50,17 +50,17 @@ numeric_scalars = array_scalars(numeric_dtypes)
 integer_or_boolean_scalars = array_scalars(integer_or_boolean_dtypes)
 boolean_scalars = array_scalars(boolean_dtypes)
 
-two_integer_dtypes = mutually_promotable_dtypes(integer_dtype_objects)
-two_floating_dtypes = mutually_promotable_dtypes(floating_dtype_objects)
-two_numeric_dtypes = mutually_promotable_dtypes(numeric_dtype_objects)
-two_integer_or_boolean_dtypes = mutually_promotable_dtypes(integer_or_boolean_dtype_objects)
-two_boolean_dtypes = mutually_promotable_dtypes(boolean_dtype_objects)
-two_any_dtypes = mutually_promotable_dtypes()
+two_integer_dtypes = mutually_promotable_dtype_pairs(integer_dtype_objects)
+two_floating_dtypes = mutually_promotable_dtype_pairs(floating_dtype_objects)
+two_numeric_dtypes = mutually_promotable_dtype_pairs(numeric_dtype_objects)
+two_integer_or_boolean_dtypes = mutually_promotable_dtype_pairs(integer_or_boolean_dtype_objects)
+two_boolean_dtypes = mutually_promotable_dtype_pairs(boolean_dtype_objects)
+two_any_dtypes = mutually_promotable_dtype_pairs()
 
 @composite
 def two_array_scalars(draw, dtype1, dtype2):
     # two_dtypes should be a strategy that returns two dtypes (like
-    # mutually_promotable_dtypes())
+    # mutually_promotable_dtype_pairs())
     return draw(array_scalars(just(dtype1))), draw(array_scalars(just(dtype2)))
 
 def sanity_check(x1, x2):

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -25,7 +25,7 @@ from .hypothesis_helpers import (integer_dtype_objects,
                                  integer_or_boolean_dtype_objects,
                                  boolean_dtype_objects, floating_dtypes,
                                  numeric_dtypes, integer_or_boolean_dtypes,
-                                 boolean_dtypes, mutually_promotable_dtype_pairs,
+                                 boolean_dtypes, mutually_promotable_dtypes,
                                  array_scalars, shared_arrays1, shared_arrays2)
 from .array_helpers import (assert_exactly_equal, negative,
                             positive_mathematical_sign,
@@ -50,17 +50,17 @@ numeric_scalars = array_scalars(numeric_dtypes)
 integer_or_boolean_scalars = array_scalars(integer_or_boolean_dtypes)
 boolean_scalars = array_scalars(boolean_dtypes)
 
-two_integer_dtypes = mutually_promotable_dtype_pairs(integer_dtype_objects)
-two_floating_dtypes = mutually_promotable_dtype_pairs(floating_dtype_objects)
-two_numeric_dtypes = mutually_promotable_dtype_pairs(numeric_dtype_objects)
-two_integer_or_boolean_dtypes = mutually_promotable_dtype_pairs(integer_or_boolean_dtype_objects)
-two_boolean_dtypes = mutually_promotable_dtype_pairs(boolean_dtype_objects)
-two_any_dtypes = mutually_promotable_dtype_pairs()
+two_integer_dtypes = mutually_promotable_dtypes(integer_dtype_objects)
+two_floating_dtypes = mutually_promotable_dtypes(floating_dtype_objects)
+two_numeric_dtypes = mutually_promotable_dtypes(numeric_dtype_objects)
+two_integer_or_boolean_dtypes = mutually_promotable_dtypes(integer_or_boolean_dtype_objects)
+two_boolean_dtypes = mutually_promotable_dtypes(boolean_dtype_objects)
+two_any_dtypes = mutually_promotable_dtypes()
 
 @composite
 def two_array_scalars(draw, dtype1, dtype2):
     # two_dtypes should be a strategy that returns two dtypes (like
-    # mutually_promotable_dtype_pairs())
+    # mutually_promotable_dtypes())
     return draw(array_scalars(just(dtype1))), draw(array_scalars(just(dtype2)))
 
 def sanity_check(x1, x2):

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -15,7 +15,7 @@ arrays of any shape, using masking patterns (similar to the tests in special_cas
 """
 
 from hypothesis import given, assume
-from hypothesis.strategies import composite, just, shared
+from hypothesis.strategies import composite, just
 
 import math
 
@@ -26,7 +26,7 @@ from .hypothesis_helpers import (integer_dtype_objects,
                                  boolean_dtype_objects, floating_dtypes,
                                  numeric_dtypes, integer_or_boolean_dtypes,
                                  boolean_dtypes, mutually_promotable_dtype_pairs,
-                                 array_scalars, two_broadcastable_shapes, xps, shared_dtypes, promotable_dtypes)
+                                 array_scalars, shared_arrays1, shared_arrays2)
 from .array_helpers import (assert_exactly_equal, negative,
                             positive_mathematical_sign,
                             negative_mathematical_sign, logical_not,
@@ -375,17 +375,7 @@ def test_divide(args):
     # have those sorts in general for this module.
 
 
-
-@given(
-    x1=xps.arrays(
-        dtype=shared_dtypes,
-        shape=shared(two_broadcastable_shapes(), key="shape_pair").map(lambda pair: pair[0])
-    ),
-    x2=xps.arrays(
-        dtype=promotable_dtypes(shared_dtypes),
-        shape=shared(two_broadcastable_shapes(), key="shape_pair").map(lambda pair: pair[1])
-    ),
-)
+@given(shared_arrays1, shared_arrays2)
 def test_equal(x1, x2):
     sanity_check(x1, x2)
     a = _array_module.equal(x1, x2)

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -26,7 +26,7 @@ from .hypothesis_helpers import (integer_dtype_objects,
                                  boolean_dtype_objects, floating_dtypes,
                                  numeric_dtypes, integer_or_boolean_dtypes,
                                  boolean_dtypes, mutually_promotable_dtype_pairs,
-                                 array_scalars, xps)
+                                 array_scalars, two_broadcastable_shapes, xps, shared_dtypes, promotable_dtypes)
 from .array_helpers import (assert_exactly_equal, negative,
                             positive_mathematical_sign,
                             negative_mathematical_sign, logical_not,
@@ -377,11 +377,13 @@ def test_divide(args):
 
 
 @given(
-    x1=shared(
-        xps.arrays(dtype=xps.scalar_dtypes(), shape=xps.array_shapes()), key='arrays'
+    x1=xps.arrays(
+        dtype=shared_dtypes,
+        shape=shared(two_broadcastable_shapes(), key="shape_pair").map(lambda pair: pair[0])
     ),
-    x2=shared(
-        xps.arrays(dtype=xps.scalar_dtypes(), shape=xps.array_shapes()), key='arrays'
+    x2=xps.arrays(
+        dtype=promotable_dtypes(shared_dtypes),
+        shape=shared(two_broadcastable_shapes(), key="shape_pair").map(lambda pair: pair[1])
     ),
 )
 def test_equal(x1, x2):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-hypothesis>=6.21.0
+hypothesis>=6.21.5
 regex
 removestar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-hypothesis
+hypothesis>=6.21.0
 regex
 removestar


### PR DESCRIPTION
This PR introduces use of [`hypothesis.extra.array_api`](https://hypothesis.readthedocs.io/en/latest/numpy.html#array-api) to generate (multi-dimensional) arrays for some existing tests, and enable the writing some new ones. I made a rudimentary proof-of-concept in #17, but this should be a serious attempt (and my main focus for the next two weeks).

 For now my priority is getting these tests up and running, and then iteratively I can follow the styles and idioms of the compliance suite properly.