### PR TITLE
Use first-party Hypothesis strategies from the `st` namespace

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -2,10 +2,7 @@ from functools import reduce
 from operator import mul
 from math import sqrt
 
-from hypothesis.strategies import (lists, integers, builds, sampled_from,
-                                   shared, tuples as hypotheses_tuples,
-                                   floats, just, composite, one_of, none,
-                                   booleans)
+from hypothesis import strategies as st
 from hypothesis.extra.numpy import mutually_broadcastable_shapes
 from hypothesis import assume
 
@@ -27,12 +24,12 @@ from .function_stubs import elementwise_functions
 # places in the tests.
 FILTER_UNDEFINED_DTYPES = True
 
-integer_dtypes = sampled_from(integer_dtype_objects)
-floating_dtypes = sampled_from(floating_dtype_objects)
-numeric_dtypes = sampled_from(numeric_dtype_objects)
-integer_or_boolean_dtypes = sampled_from(integer_or_boolean_dtype_objects)
-boolean_dtypes = sampled_from(boolean_dtype_objects)
-dtypes = sampled_from(dtype_objects)
+integer_dtypes = st.sampled_from(integer_dtype_objects)
+floating_dtypes = st.sampled_from(floating_dtype_objects)
+numeric_dtypes = st.sampled_from(numeric_dtype_objects)
+integer_or_boolean_dtypes = st.sampled_from(integer_or_boolean_dtype_objects)
+boolean_dtypes = st.sampled_from(boolean_dtype_objects)
+dtypes = st.sampled_from(dtype_objects)
 
 if FILTER_UNDEFINED_DTYPES:
     integer_dtypes = integer_dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
@@ -43,12 +40,12 @@ if FILTER_UNDEFINED_DTYPES:
     boolean_dtypes = boolean_dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
     dtypes = dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
 
-shared_dtypes = shared(dtypes)
+shared_dtypes = st.shared(dtypes)
 
-@composite
+@st.composite
 def mutually_promotable_dtypes(draw, dtype_objects=dtype_objects):
     from .test_type_promotion import dtype_mapping, promotion_table
-    # sort for shrinking (sampled_from shrinks to the earlier elements in the
+    # sort for shrinking (st.sampled_from shrinks to the earlier elements in the
     # list). Give pairs of the same dtypes first, then smaller dtypes,
     # preferring float, then int, then unsigned int. Note, this might not
     # always result in examples shrinking to these pairs because strategies
@@ -66,13 +63,13 @@ def mutually_promotable_dtypes(draw, dtype_objects=dtype_objects):
         filtered_dtype_pairs = [(i, j) for i, j in filtered_dtype_pairs
                                 if not isinstance(i, _UndefinedStub)
                                 and not isinstance(j, _UndefinedStub)]
-    return draw(sampled_from(filtered_dtype_pairs))
+    return draw(st.sampled_from(filtered_dtype_pairs))
 
-# shared() allows us to draw either the function or the function name and they
+# st.shared() allows us to draw either the function or the function name and they
 # will both correspond to the same function.
 
-# TODO: Extend this to all functions, not just elementwise
-elementwise_functions_names = shared(sampled_from(elementwise_functions.__all__))
+# TODO: Extend this to all functions, not st.just elementwise
+elementwise_functions_names = st.shared(st.sampled_from(elementwise_functions.__all__))
 array_functions_names = elementwise_functions_names
 multiarg_array_functions_names = array_functions_names.filter(
     lambda func_name: nargs(func_name) > 1)
@@ -92,23 +89,23 @@ SQRT_MAX_ARRAY_SIZE = int(sqrt(MAX_ARRAY_SIZE))
 def prod(seq):
     return reduce(mul, seq, 1)
 
-# hypotheses.strategies.tuples only generates tuples of a fixed size
+# st.tuples() only generates tuples of a fixed size
 def tuples(elements, *, min_size=0, max_size=None, unique_by=None, unique=False):
-    return lists(elements, min_size=min_size, max_size=max_size,
+    return st.lists(elements, min_size=min_size, max_size=max_size,
                  unique_by=unique_by, unique=unique).map(tuple)
 
-shapes = tuples(integers(0, 10)).filter(lambda shape: prod(shape) < MAX_ARRAY_SIZE)
+shapes = tuples(st.integers(0, 10)).filter(lambda shape: prod(shape) < MAX_ARRAY_SIZE)
 
 # Use this to avoid memory errors with NumPy.
 # See https://github.com/numpy/numpy/issues/15753
-shapes = tuples(integers(0, 10)).filter(
+shapes = tuples(st.integers(0, 10)).filter(
              lambda shape: prod([i for i in shape if i]) < MAX_ARRAY_SIZE)
 
 two_mutually_broadcastable_shapes = mutually_broadcastable_shapes(num_shapes=2)\
     .map(lambda S: S.input_shapes)\
     .filter(lambda S: all(prod([i for i in shape if i]) < MAX_ARRAY_SIZE for shape in S))
 
-@composite
+@st.composite
 def two_broadcastable_shapes(draw, shapes=shapes):
     """
     This will produce two shapes (shape1, shape2) such that shape2 can be
@@ -122,17 +119,17 @@ def two_broadcastable_shapes(draw, shapes=shapes):
         assume(False)
     return (shape1, shape2)
 
-sizes = integers(0, MAX_ARRAY_SIZE)
-sqrt_sizes = integers(0, SQRT_MAX_ARRAY_SIZE)
+sizes = st.integers(0, MAX_ARRAY_SIZE)
+sqrt_sizes = st.integers(0, SQRT_MAX_ARRAY_SIZE)
 
-ones_arrays = builds(ones, shapes, dtype=shared_dtypes)
+ones_arrays = st.builds(ones, shapes, dtype=shared_dtypes)
 
-nonbroadcastable_ones_array_two_args = hypotheses_tuples(ones_arrays, ones_arrays)
+nonbroadcastable_ones_array_two_args = st.tuples(ones_arrays, ones_arrays)
 
-# TODO: Generate general arrays here, rather than just scalars.
-numeric_arrays = builds(full, just((1,)), floats())
+# TODO: Generate general arrays here, rather than st.just scalars.
+numeric_arrays = st.builds(full, st.just((1,)), st.floats())
 
-@composite
+@st.composite
 def scalars(draw, dtypes, finite=False):
     """
     Strategy to generate a scalar that matches a dtype strategy
@@ -142,54 +139,54 @@ def scalars(draw, dtypes, finite=False):
     dtype = draw(dtypes)
     if dtype in dtype_ranges:
         m, M = dtype_ranges[dtype]
-        return draw(integers(m, M))
+        return draw(st.integers(m, M))
     elif dtype == bool_dtype:
-        return draw(booleans())
+        return draw(st.booleans())
     elif dtype == float64:
         if finite:
-            return draw(floats(allow_nan=False, allow_infinity=False))
-        return draw(floats())
+            return draw(st.floats(allow_nan=False, allow_infinity=False))
+        return draw(st.floats())
     elif dtype == float32:
         if finite:
-            return draw(floats(width=32, allow_nan=False, allow_infinity=False))
-        return draw(floats(width=32))
+            return draw(st.floats(width=32, allow_nan=False, allow_infinity=False))
+        return draw(st.floats(width=32))
     else:
         raise ValueError(f"Unrecognized dtype {dtype}")
 
-@composite
+@st.composite
 def array_scalars(draw, dtypes):
     dtype = draw(dtypes)
-    return full((), draw(scalars(just(dtype))), dtype=dtype)
+    return full((), draw(scalars(st.just(dtype))), dtype=dtype)
 
-@composite
+@st.composite
 def python_integer_indices(draw, sizes):
     size = draw(sizes)
     if size == 0:
         assume(False)
-    return draw(integers(-size, size - 1))
+    return draw(st.integers(-size, size - 1))
 
-@composite
+@st.composite
 def integer_indices(draw, sizes):
     # Return either a Python integer or a 0-D array with some integer dtype
     idx = draw(python_integer_indices(sizes))
     dtype = draw(integer_dtypes)
     m, M = dtype_ranges[dtype]
     if m <= idx <= M:
-        return draw(one_of(just(idx),
-                           just(full((), idx, dtype=dtype))))
+        return draw(st.one_of(st.just(idx),
+                           st.just(full((), idx, dtype=dtype))))
     return idx
 
-@composite
+@st.composite
 def slices(draw, sizes):
     size = draw(sizes)
     # The spec does not specify out of bounds behavior.
-    max_step_size = draw(integers(1, max(1, size)))
-    step = draw(one_of(integers(-max_step_size, -1), integers(1, max_step_size), none()))
-    start = draw(one_of(integers(-size, max(0, size-1)), none()))
+    max_step_size = draw(st.integers(1, max(1, size)))
+    step = draw(st.one_of(st.integers(-max_step_size, -1), st.integers(1, max_step_size), st.none()))
+    start = draw(st.one_of(st.integers(-size, max(0, size-1)), st.none()))
     if step is None or step > 0:
-        stop = draw(one_of(integers(-size, size)), none())
+        stop = draw(st.one_of(st.integers(-size, size)), st.none())
     else:
-        stop = draw(one_of(integers(-size - 1, size - 1)), none())
+        stop = draw(st.one_of(st.integers(-size - 1, size - 1)), st.none())
     s = slice(start, stop, step)
     l = list(range(size))
     sliced_list = l[s]
@@ -204,23 +201,23 @@ def slices(draw, sizes):
         assume(False)
     return s
 
-@composite
+@st.composite
 def multiaxis_indices(draw, shapes):
     res = []
-    # Generate tuples no longer than the shape, with indices corresponding to
+    # Generate st.tuples no longer than the shape, with indices corresponding to
     # each dimension.
     shape = draw(shapes)
-    n_entries = draw(integers(0, len(shape)))
+    n_entries = draw(st.integers(0, len(shape)))
     # from hypothesis import note
     # note(f"multiaxis_indices n_entries: {n_entries}")
 
     k = 0
     for i in range(n_entries):
         size = shape[k]
-        idx = draw(one_of(
-            integer_indices(just(size)),
-            slices(just(size)),
-            just(...)))
+        idx = draw(st.one_of(
+            integer_indices(st.just(size)),
+            slices(st.just(size)),
+            st.just(...)))
         if idx is ... and k >= 0:
             # If there is an ellipsis, index from the end of the shape
             k = k - n_entries
@@ -232,6 +229,6 @@ def multiaxis_indices(draw, shapes):
     res_has_ellipsis = any(i is ... for i in res)
     if n_entries == len(shape) and not res_has_ellipsis:
         # note("Adding extra")
-        extra = draw(lists(one_of(integer_indices(sizes), slices(sizes)), min_size=0, max_size=3))
+        extra = draw(st.lists(st.one_of(integer_indices(sizes), slices(sizes)), min_size=0, max_size=3))
         res += extra
     return tuple(res)

--- a/array_api_tests/meta_tests/test_array_helpers.py
+++ b/array_api_tests/meta_tests/test_array_helpers.py
@@ -3,8 +3,7 @@ from ..hypothesis_helpers import integer_dtypes
 from ..test_type_promotion import dtype_nbits, dtype_signed
 from .._array_module import asarray, nan, equal, all
 
-from hypothesis import given, assume
-from hypothesis.strategies import integers
+from hypothesis import given, assume, strategies as st
 
 # TODO: These meta-tests currently only work with NumPy
 
@@ -22,7 +21,7 @@ def test_notequal():
     res = asarray([False, True, False, False, False, True, False, True])
     assert all(equal(notequal(a, b), res))
 
-@given(integers(), integer_dtypes)
+@given(st.integers(), integer_dtypes)
 def test_int_to_dtype(x, dtype):
     n = dtype_nbits(dtype)
     signed = dtype_signed(dtype)

--- a/array_api_tests/test_broadcasting.py
+++ b/array_api_tests/test_broadcasting.py
@@ -4,8 +4,7 @@ https://github.com/data-apis/array-api/blob/master/spec/API_specification/broadc
 
 import pytest
 
-from hypothesis import given, assume
-from hypothesis.strategies import data, sampled_from
+from hypothesis import given, assume, strategies as st
 
 from .hypothesis_helpers import shapes, FILTER_UNDEFINED_DTYPES
 from .pytest_helpers import raises, doesnt_raise, nargs
@@ -111,12 +110,12 @@ def test_broadcast_shapes_explicit_spec():
 @pytest.mark.parametrize('func_name', [i for i in
                                        elementwise_functions.__all__ if
                                        nargs(i) > 1])
-@given(shape1=shapes, shape2=shapes, dtype=data())
+@given(shape1=shapes, shape2=shapes, dtype=st.data())
 def test_broadcasting_hypothesis(func_name, shape1, shape2, dtype):
     # Internal consistency checks
     assert nargs(func_name) == 2
 
-    dtype = dtype_mapping[dtype.draw(sampled_from(input_types[elementwise_function_input_types[func_name]]))]
+    dtype = dtype_mapping[dtype.draw(st.sampled_from(input_types[elementwise_function_input_types[func_name]]))]
     if FILTER_UNDEFINED_DTYPES and isinstance(dtype, _UndefinedStub):
         assume(False)
     func = getattr(_array_module, func_name)

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -6,17 +6,16 @@ from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
                                  shapes, sizes, sqrt_sizes, shared_dtypes,
                                  scalars)
 
-from hypothesis import assume, given
-from hypothesis.strategies import integers, floats, one_of, none, booleans, just
+from hypothesis import assume, given, strategies as st
 
-int_range = integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE)
-float_range = floats(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE,
+int_range = st.integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE)
+float_range = st.floats(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE,
                      allow_nan=False)
-@given(one_of(int_range, float_range),
-       one_of(none(), int_range, float_range),
-       one_of(none(), int_range, float_range).filter(lambda x: x != 0
+@given(st.one_of(int_range, float_range),
+       st.one_of(st.none(), int_range, float_range),
+       st.one_of(st.none(), int_range, float_range).filter(lambda x: x != 0
                                                      and (abs(x) > 0.01 if isinstance(x, float) else True)),
-       one_of(none(), numeric_dtypes))
+       st.one_of(st.none(), numeric_dtypes))
 def test_arange(start, stop, step, dtype):
     if dtype in dtype_ranges:
         m, M = dtype_ranges[dtype]
@@ -64,7 +63,7 @@ def test_arange(start, stop, step, dtype):
                  or step < 0 and stop <= start)):
             assert a.size == ceil(asarray((stop-start)/step)), "arange() produced an array of the incorrect size"
 
-@given(one_of(shapes, sizes), one_of(none(), dtypes))
+@given(st.one_of(shapes, sizes), st.one_of(st.none(), dtypes))
 def test_empty(shape, dtype):
     if dtype is None:
         a = empty(shape)
@@ -84,7 +83,7 @@ def test_empty_like():
 # TODO: Use this method for all optional arguments
 optional_marker = object()
 
-@given(sqrt_sizes, one_of(just(optional_marker), none(), sqrt_sizes), one_of(none(), integers()), numeric_dtypes)
+@given(sqrt_sizes, st.one_of(st.just(optional_marker), st.none(), sqrt_sizes), st.one_of(st.none(), st.integers()), numeric_dtypes)
 def test_eye(n_rows, n_cols, k, dtype):
     kwargs = {k: v for k, v in {'k': k, 'dtype': dtype}.items() if v
               is not None}
@@ -111,7 +110,7 @@ def test_eye(n_rows, n_cols, k, dtype):
             else:
                 assert a[i, j] == 0, "eye() did not produce a 0 off the diagonal"
 
-@given(shapes, scalars(shared_dtypes), one_of(none(), shared_dtypes))
+@given(shapes, scalars(shared_dtypes), st.one_of(st.none(), shared_dtypes))
 def test_full(shape, fill_value, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
 
@@ -137,8 +136,8 @@ def test_full_like():
 @given(scalars(shared_dtypes, finite=True),
        scalars(shared_dtypes, finite=True),
        sizes,
-       one_of(none(), shared_dtypes),
-       one_of(none(), booleans()),)
+       st.one_of(st.none(), shared_dtypes),
+       st.one_of(st.none(), st.booleans()),)
 def test_linspace(start, stop, num, dtype, endpoint):
     # Skip on int start or stop that cannot be exactly represented as a float,
     # since we do not have good approx_equal helpers yet.
@@ -177,7 +176,7 @@ def test_linspace(start, stop, num, dtype, endpoint):
         # for i in range(1, num):
         #     assert all(equal(a[i], full((), i*(stop - start)/n + start, dtype=dtype))), f"linspace() produced an array with an incorrect value at index {i}"
 
-@given(shapes, one_of(none(), dtypes))
+@given(shapes, st.one_of(st.none(), dtypes))
 def test_ones(shape, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
     if dtype is None or is_float_dtype(dtype):
@@ -203,7 +202,7 @@ def test_ones(shape, dtype):
 def test_ones_like():
     pass
 
-@given(shapes, one_of(none(), dtypes))
+@given(shapes, st.one_of(st.none(), dtypes))
 def test_zeros(shape, dtype):
     kwargs = {} if dtype is None else {'dtype': dtype}
     if dtype is None or is_float_dtype(dtype):

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -14,8 +14,7 @@ arrays of any shape, using masking patterns (similar to the tests in special_cas
 
 """
 
-from hypothesis import given, assume
-from hypothesis.strategies import composite, just
+from hypothesis import given, assume, strategies as st
 
 import math
 
@@ -57,11 +56,11 @@ two_integer_or_boolean_dtypes = mutually_promotable_dtypes(integer_or_boolean_dt
 two_boolean_dtypes = mutually_promotable_dtypes(boolean_dtype_objects)
 two_any_dtypes = mutually_promotable_dtypes()
 
-@composite
+@st.composite
 def two_array_scalars(draw, dtype1, dtype2):
     # two_dtypes should be a strategy that returns two dtypes (like
     # mutually_promotable_dtypes())
-    return draw(array_scalars(just(dtype1))), draw(array_scalars(just(dtype2)))
+    return draw(array_scalars(st.just(dtype1))), draw(array_scalars(st.just(dtype2)))
 
 def sanity_check(x1, x2):
     try:

--- a/array_api_tests/test_indexing.py
+++ b/array_api_tests/test_indexing.py
@@ -5,8 +5,7 @@ For these tests, we only need arrays where each element is distinct, so we use
 arange().
 """
 
-from hypothesis import given
-from hypothesis.strategies import shared
+from hypothesis import given, strategies as st
 
 from .array_helpers import assert_exactly_equal
 from .hypothesis_helpers import (slices, sizes, integer_indices, shapes, prod,
@@ -16,7 +15,7 @@ from ._array_module import arange, reshape
 
 # TODO: Add tests for __setitem__
 
-@given(shared(sizes, key='array_sizes'), integer_indices(shared(sizes, key='array_sizes')))
+@given(st.shared(sizes, key='array_sizes'), integer_indices(st.shared(sizes, key='array_sizes')))
 def test_integer_indexing(size, idx):
     # Test that indices on single dimensional arrays give the same result as
     # Python lists. idx may be a Python integer or a 0-D array with integer dtype.
@@ -35,7 +34,7 @@ def test_integer_indexing(size, idx):
     assert sliced_array.dtype == a.dtype, "Integer indices should not change the dtype"
     assert sliced_array == sliced_list, "Integer index did not give the correct entry"
 
-@given(shared(sizes, key='array_sizes'), slices(shared(sizes, key='array_sizes')))
+@given(st.shared(sizes, key='array_sizes'), slices(st.shared(sizes, key='array_sizes')))
 def test_slicing(size, s):
     # Test that slices on arrays give the same result as Python lists.
 
@@ -58,8 +57,8 @@ def test_slicing(size, s):
     for i in range(len(sliced_list)):
         assert sliced_array[i] == sliced_list[i], "Slice index did not give the same elements as slicing an equivalent Python list"
 
-@given(shared(shapes, key='array_shapes'),
-       multiaxis_indices(shapes=shared(shapes, key='array_shapes')))
+@given(st.shared(shapes, key='array_shapes'),
+       multiaxis_indices(shapes=st.shared(shapes, key='array_shapes')))
 def test_multiaxis_indexing(shape, idx):
     # NOTE: Out of bounds indices (both integer and slices) are out of scope
     # for the spec. If you get a (valid) out of bounds error, it indicates a

--- a/array_api_tests/test_type_promotion.py
+++ b/array_api_tests/test_type_promotion.py
@@ -4,8 +4,7 @@ https://data-apis.github.io/array-api/latest/API_specification/type_promotion.ht
 
 import pytest
 
-from hypothesis import given
-from hypothesis.strategies import from_type, data, integers, just
+from hypothesis import given, strategies as st
 
 from .hypothesis_helpers import (shapes, two_mutually_broadcastable_shapes,
                                  two_broadcastable_shapes, scalars)
@@ -374,10 +373,10 @@ elementwise_function_two_arg_bool_parametrize_ids = ['-'.join((n, d1, d2)) for n
                          elementwise_function_two_arg_bool_parametrize_inputs,
                          ids=elementwise_function_two_arg_bool_parametrize_ids)
 # The spec explicitly requires type promotion to work for shape 0
-# Unfortunately, data(), isn't compatible with @example, so this is commented
+# Unfortunately, st.data(), isn't compatible with @example, so this is commented
 # out for now.
 # @example(shape=(0,))
-@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=data())
+@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=st.data())
 def test_elementwise_function_two_arg_bool_type_promotion(func_name,
                                                               two_shapes, dtypes,
                                                               fillvalues):
@@ -388,11 +387,11 @@ def test_elementwise_function_two_arg_bool_type_promotion(func_name,
     dtype1 = dtype_mapping[type1]
     dtype2 = dtype_mapping[type2]
 
-    fillvalue1 = fillvalues.draw(scalars(just(dtype1)))
+    fillvalue1 = fillvalues.draw(scalars(st.just(dtype1)))
     if func_name in ['bitwise_left_shift', 'bitwise_right_shift']:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)).filter(lambda x: x > 0))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)).filter(lambda x: x > 0))
     else:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)))
 
 
     for i in [func, dtype1, dtype2]:
@@ -422,16 +421,16 @@ elementwise_function_two_arg_promoted_parametrize_inputs = [(func_name, dtypes)
 elementwise_function_two_arg_promoted_parametrize_ids = ['-'.join((n, d1, d2)) for n, ((d1, d2), _)
                                             in elementwise_function_two_arg_promoted_parametrize_inputs]
 
-# TODO: Extend this to all functions (not just elementwise), and handle
+# TODO: Extend this to all functions (not st.just elementwise), and handle
 # functions that take more than 2 args
 @pytest.mark.parametrize('func_name,dtypes',
                          elementwise_function_two_arg_promoted_parametrize_inputs,
                          ids=elementwise_function_two_arg_promoted_parametrize_ids)
 # The spec explicitly requires type promotion to work for shape 0
-# Unfortunately, data(), isn't compatible with @example, so this is commented
+# Unfortunately, st.data(), isn't compatible with @example, so this is commented
 # out for now.
 # @example(shape=(0,))
-@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=data())
+@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=st.data())
 def test_elementwise_function_two_arg_promoted_type_promotion(func_name,
                                                               two_shapes, dtypes,
                                                               fillvalues):
@@ -442,11 +441,11 @@ def test_elementwise_function_two_arg_promoted_type_promotion(func_name,
     dtype1 = dtype_mapping[type1]
     dtype2 = dtype_mapping[type2]
     res_dtype = dtype_mapping[res_type]
-    fillvalue1 = fillvalues.draw(scalars(just(dtype1)))
+    fillvalue1 = fillvalues.draw(scalars(st.just(dtype1)))
     if func_name in ['bitwise_left_shift', 'bitwise_right_shift']:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)).filter(lambda x: x > 0))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)).filter(lambda x: x > 0))
     else:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)))
 
 
     for i in [func, dtype1, dtype2, res_dtype]:
@@ -476,23 +475,23 @@ elementwise_function_one_arg_bool_parametrize_inputs = [(func_name, dtypes)
 elementwise_function_one_arg_bool_parametrize_ids = ['-'.join((n, d)) for n, d
                                             in elementwise_function_one_arg_bool_parametrize_inputs]
 
-# TODO: Extend this to all functions (not just elementwise), and handle
+# TODO: Extend this to all functions (not st.just elementwise), and handle
 # functions that take more than 2 args
 @pytest.mark.parametrize('func_name,dtype_name',
                          elementwise_function_one_arg_bool_parametrize_inputs,
                          ids=elementwise_function_one_arg_bool_parametrize_ids)
 # The spec explicitly requires type promotion to work for shape 0
-# Unfortunately, data(), isn't compatible with @example, so this is commented
+# Unfortunately, st.data(), isn't compatible with @example, so this is commented
 # out for now.
 # @example(shape=(0,))
-@given(shape=shapes, fillvalues=data())
+@given(shape=shapes, fillvalues=st.data())
 def test_elementwise_function_one_arg_bool(func_name, shape,
                                                      dtype_name, fillvalues):
     assert nargs(func_name) == 1
     func = getattr(_array_module, func_name)
 
     dtype = dtype_mapping[dtype_name]
-    fillvalue = fillvalues.draw(scalars(just(dtype)))
+    fillvalue = fillvalues.draw(scalars(st.just(dtype)))
 
     for i in [func, dtype]:
         if isinstance(i, _array_module._UndefinedStub):
@@ -515,23 +514,23 @@ elementwise_function_one_arg_promoted_parametrize_inputs = [(func_name, dtypes)
 elementwise_function_one_arg_promoted_parametrize_ids = ['-'.join((n, d)) for n, d
                                             in elementwise_function_one_arg_promoted_parametrize_inputs]
 
-# TODO: Extend this to all functions (not just elementwise), and handle
+# TODO: Extend this to all functions (not st.just elementwise), and handle
 # functions that take more than 2 args
 @pytest.mark.parametrize('func_name,dtype_name',
                          elementwise_function_one_arg_promoted_parametrize_inputs,
                          ids=elementwise_function_one_arg_promoted_parametrize_ids)
 # The spec explicitly requires type promotion to work for shape 0
-# Unfortunately, data(), isn't compatible with @example, so this is commented
+# Unfortunately, st.data(), isn't compatible with @example, so this is commented
 # out for now.
 # @example(shape=(0,))
-@given(shape=shapes, fillvalues=data())
+@given(shape=shapes, fillvalues=st.data())
 def test_elementwise_function_one_arg_type_promotion(func_name, shape,
                                                      dtype_name, fillvalues):
     assert nargs(func_name) == 1
     func = getattr(_array_module, func_name)
 
     dtype = dtype_mapping[dtype_name]
-    fillvalue = fillvalues.draw(scalars(just(dtype)))
+    fillvalue = fillvalues.draw(scalars(st.just(dtype)))
 
     for i in [func, dtype]:
         if isinstance(i, _array_module._UndefinedStub):
@@ -552,21 +551,21 @@ operator_one_arg_promoted_parametrize_ids = ['-'.join((n, d)) for n, d
                                             in operator_one_arg_promoted_parametrize_inputs]
 
 
-# TODO: Extend this to all functions (not just elementwise), and handle
+# TODO: Extend this to all functions (not st.just elementwise), and handle
 # functions that take more than 2 args
 @pytest.mark.parametrize('unary_op_name,dtype_name',
                          operator_one_arg_promoted_parametrize_inputs,
                          ids=operator_one_arg_promoted_parametrize_ids)
 # The spec explicitly requires type promotion to work for shape 0
-# Unfortunately, data(), isn't compatible with @example, so this is commented
+# Unfortunately, st.data(), isn't compatible with @example, so this is commented
 # out for now.
 # @example(shape=(0,))
-@given(shape=shapes, fillvalues=data())
+@given(shape=shapes, fillvalues=st.data())
 def test_operator_one_arg_type_promotion(unary_op_name, shape, dtype_name, fillvalues):
     unary_op = unary_operators[unary_op_name]
 
     dtype = dtype_mapping[dtype_name]
-    fillvalue = fillvalues.draw(scalars(just(dtype)))
+    fillvalue = fillvalues.draw(scalars(st.just(dtype)))
 
     if isinstance(dtype, _array_module._UndefinedStub):
         dtype._raise()
@@ -598,7 +597,7 @@ operator_two_arg_bool_parametrize_ids = ['-'.join((n, d1, d2)) for n, (d1, d2)
 @pytest.mark.parametrize('binary_op_name,dtypes',
                          operator_two_arg_bool_parametrize_inputs,
                          ids=operator_two_arg_bool_parametrize_ids)
-@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=data())
+@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=st.data())
 def test_operator_two_arg_bool_promotion(binary_op_name, dtypes, two_shapes,
                                     fillvalues):
     binary_op = binary_operators[binary_op_name]
@@ -606,8 +605,8 @@ def test_operator_two_arg_bool_promotion(binary_op_name, dtypes, two_shapes,
     type1, type2 = dtypes
     dtype1 = dtype_mapping[type1]
     dtype2 = dtype_mapping[type2]
-    fillvalue1 = fillvalues.draw(scalars(just(dtype1)))
-    fillvalue2 = fillvalues.draw(scalars(just(dtype2)))
+    fillvalue1 = fillvalues.draw(scalars(st.just(dtype1)))
+    fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)))
 
     for i in [dtype1, dtype2]:
         if isinstance(i, _array_module._UndefinedStub):
@@ -636,7 +635,7 @@ operator_two_arg_promoted_parametrize_ids = ['-'.join((n, d1, d2)) for n, ((d1, 
 @pytest.mark.parametrize('binary_op_name,dtypes',
                          operator_two_arg_promoted_parametrize_inputs,
                          ids=operator_two_arg_promoted_parametrize_ids)
-@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=data())
+@given(two_shapes=two_mutually_broadcastable_shapes, fillvalues=st.data())
 def test_operator_two_arg_promoted_promotion(binary_op_name, dtypes, two_shapes,
                                     fillvalues):
     binary_op = binary_operators[binary_op_name]
@@ -645,11 +644,11 @@ def test_operator_two_arg_promoted_promotion(binary_op_name, dtypes, two_shapes,
     dtype1 = dtype_mapping[type1]
     dtype2 = dtype_mapping[type2]
     res_dtype = dtype_mapping[res_type]
-    fillvalue1 = fillvalues.draw(scalars(just(dtype1)))
+    fillvalue1 = fillvalues.draw(scalars(st.just(dtype1)))
     if binary_op_name in ['>>', '<<']:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)).filter(lambda x: x > 0))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)).filter(lambda x: x > 0))
     else:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)))
 
 
     for i in [dtype1, dtype2, res_dtype]:
@@ -674,7 +673,7 @@ operator_inplace_two_arg_promoted_parametrize_ids = ['-'.join((n[:2] + 'i' + n[2
 @pytest.mark.parametrize('binary_op_name,dtypes',
                          operator_inplace_two_arg_promoted_parametrize_inputs,
                          ids=operator_inplace_two_arg_promoted_parametrize_ids)
-@given(two_shapes=two_broadcastable_shapes(), fillvalues=data())
+@given(two_shapes=two_broadcastable_shapes(), fillvalues=st.data())
 def test_operator_inplace_two_arg_promoted_promotion(binary_op_name, dtypes, two_shapes,
                                     fillvalues):
     binary_op = binary_operators[binary_op_name]
@@ -683,11 +682,11 @@ def test_operator_inplace_two_arg_promoted_promotion(binary_op_name, dtypes, two
     dtype1 = dtype_mapping[type1]
     dtype2 = dtype_mapping[type2]
     res_dtype = dtype_mapping[res_type]
-    fillvalue1 = fillvalues.draw(scalars(just(dtype1)))
+    fillvalue1 = fillvalues.draw(scalars(st.just(dtype1)))
     if binary_op_name in ['>>', '<<']:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)).filter(lambda x: x > 0))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)).filter(lambda x: x > 0))
     else:
-        fillvalue2 = fillvalues.draw(scalars(just(dtype2)))
+        fillvalue2 = fillvalues.draw(scalars(st.just(dtype2)))
 
     for i in [dtype1, dtype2, res_dtype]:
         if isinstance(i, _array_module._UndefinedStub):
@@ -713,11 +712,11 @@ scalar_promotion_parametrize_inputs = [(binary_op_name, dtype_name, scalar_type)
 
 @pytest.mark.parametrize('binary_op_name,dtype_name,scalar_type',
                          scalar_promotion_parametrize_inputs)
-@given(shape=shapes, python_scalars=data(), fillvalues=data())
+@given(shape=shapes, python_scalars=st.data(), fillvalues=st.data())
 def test_operator_scalar_promotion(binary_op_name, dtype_name, scalar_type,
                                    shape, python_scalars, fillvalues):
     """
-    See https://data-apis.github.io/array-api/latest/API_specification/type_promotion.html#mixing-arrays-with-python-scalars
+    See https://st.data-apis.github.io/array-api/latest/API_specification/type_promotion.html#mixing-arrays-with-python-scalars
     """
     binary_op = binary_operators[binary_op_name]
     if binary_op == '@':
@@ -725,13 +724,13 @@ def test_operator_scalar_promotion(binary_op_name, dtype_name, scalar_type,
     dtype = dtype_mapping[dtype_name]
 
     if dtype_name in input_types['integer']:
-        s = python_scalars.draw(integers(*dtype_ranges[dtype]))
+        s = python_scalars.draw(st.integers(*dtype_ranges[dtype]))
     else:
-        s = python_scalars.draw(from_type(scalar_type))
+        s = python_scalars.draw(st.from_type(scalar_type))
     scalar_as_array = _array_module.asarray(s, dtype=dtype)
     get_locals = lambda: dict(a=a, s=s, scalar_as_array=scalar_as_array)
 
-    fillvalue = fillvalues.draw(scalars(just(dtype)))
+    fillvalue = fillvalues.draw(scalars(st.just(dtype)))
     a = full(shape, fillvalue, dtype=dtype)
 
     # As per the spec:


### PR DESCRIPTION
As discussed in #18, this PR simply removes all instances of `from hypothesis.strategies import ...` in favour of `from hypothesis import strategies as st`, so that first-party strategies are used like `st.<strategy>`.

If you like, I could go over the suite to aias `_array_module` as `xp` and only call array module objects/methods with `xp.<attribute>`. Even if `_array_module` is really just a wrapper, it may add more clarity overall. Likewise I can try namespacing `hypothesis_helpers` and `array_helpers` if you'd like.