### PR TITLE
Add `pre-commit` config for pyflakes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,5 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pyflakes
-    - name: Lint with pyfalkes
-      run: |
-        pyflakes .
+    - name: Run pre-commit hook
+      uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '4.0.1'
+    hooks:
+    -   id: flake8
+        args: [--select, F]


### PR DESCRIPTION
I keep on forgetting to run `pyflakes` before pushing, so I thought I'd use [`pre-commit`](https://pre-commit.com/). Here's a minimal config for the tool. As there doesn't seem to be a `pre-commit` hook for `pyflakes` itself, I just use `flake8` and run only the pyflake-related checks via `flake8 --select F`. I've also updated the linting workflow to use `pre-commit`, to keep consistency (although I doubt `flake8` versions will change the pyflake linting behaviour).

It is "another thing", so I understand if you're not interested in merging. For the future I was thinking it might be nice to create a custom `pre-commit` hook that ensured any staged changes to `./generate_stubs.py` would trigger a check to see the related files have been updated.