### PR TITLE
Refactor assertions in `test_creation.py`

### DIFF
--- a/array_api_tests/meta/test_utils.py
+++ b/array_api_tests/meta/test_utils.py
@@ -1,9 +1,26 @@
+import pytest
+
 from ..test_signatures import extension_module
+from ..test_creation_functions import frange
 
 
 def test_extension_module_is_extension():
-    assert extension_module('linalg')
+    assert extension_module("linalg")
 
 
 def test_extension_func_is_not_extension():
-    assert not extension_module('linalg.cross')
+    assert not extension_module("linalg.cross")
+
+
+@pytest.mark.parametrize(
+    "r, size, elements",
+    [
+        (frange(0, 1, 1), 1, [0]),
+        (frange(1, 0, -1), 1, [1]),
+        (frange(0, 1, -1), 0, []),
+        (frange(0, 1, 2), 1, [0]),
+    ],
+)
+def test_frange(r, size, elements):
+    assert len(r) == size
+    assert list(r) == elements

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -11,6 +11,7 @@ __all__ = [
     "raises",
     "doesnt_raise",
     "nargs",
+    "fmt_kw",
     "assert_dtype",
     "assert_kw_dtype",
     "assert_default_float",
@@ -58,7 +59,7 @@ def nargs(func_name):
     return len(getfullargspec(getattr(function_stubs, func_name)).args)
 
 
-def _fmt_kw(kw: Dict[str, Any]) -> str:
+def fmt_kw(kw: Dict[str, Any]) -> str:
     return ", ".join(f"{k}={v}" for k, v in kw.items())
 
 
@@ -120,7 +121,7 @@ def assert_shape(
     if isinstance(expected, int):
         expected = (expected,)
     msg = (
-        f"out.shape={out_shape}, but should be {expected} [{func_name}({_fmt_kw(kw)})]"
+        f"out.shape={out_shape}, but should be {expected} [{func_name}({fmt_kw(kw)})]"
     )
     assert out_shape == expected, msg
 
@@ -128,7 +129,7 @@ def assert_shape(
 def assert_fill(
     func_name: str, fill_value: Scalar, dtype: DataType, out: Array, /, **kw
 ):
-    msg = f"out not filled with {fill_value} [{func_name}({_fmt_kw(kw)})]\n{out=}"
+    msg = f"out not filled with {fill_value} [{func_name}({fmt_kw(kw)})]\n{out=}"
     if math.isnan(fill_value):
         assert ah.all(ah.isnan(out)), msg
     else:

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -2,23 +2,19 @@ import math
 from typing import Union
 from itertools import takewhile, count
 
-from ._array_module import (asarray, arange, empty, empty_like, eye, full,
-                            full_like, equal, linspace, ones, ones_like,
-                            zeros, zeros_like, isnan)
+from hypothesis import assume, given, strategies as st
+
 from . import _array_module as xp
-from .array_helpers import assert_exactly_equal, isintegral
-from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
-                                 shapes, sizes, sqrt_sizes, shared_dtypes,
-                                 scalars, kwargs)
+from . import array_helpers as ah
+from . import hypothesis_helpers as hh
 from . import dtype_helpers as dh
 from . import xps
 
-from hypothesis import assume, given, strategies as st
 
 
 # Testing xp.arange() requires bounding the start/stop/step arguments to only
 # test argument combinations compliant with the Array API, as well as to not
-# produce arrays with sizes not supproted by an array module.
+# produce arrays with hh.sizes not supproted by an array module.
 #
 # We first make sure generated integers can be represented by an array module's
 # default integer type, as even if a float array should be produced a module
@@ -27,8 +23,8 @@ from hypothesis import assume, given, strategies as st
 # This means that float arguments also need to be bound, so that they do not
 # require any integer arguments to be outside the representable bounds.
 int_min, int_max = dh.dtype_ranges[dh.default_int]
-float_min = float(int_min * (MAX_ARRAY_SIZE - 1))
-float_max = float(int_max * (MAX_ARRAY_SIZE - 1))
+float_min = float(int_min * (hh.MAX_ARRAY_SIZE - 1))
+float_max = float(int_max * (hh.MAX_ARRAY_SIZE - 1))
 
 
 def reals(min_value=None, max_value=None) -> st.SearchStrategy[Union[int, float]]:
@@ -52,7 +48,7 @@ def reals(min_value=None, max_value=None) -> st.SearchStrategy[Union[int, float]
     )
 
 
-@given(start=reals(), dtype=st.none() | numeric_dtypes, data=st.data())
+@given(start=reals(), dtype=st.none() | hh.numeric_dtypes, data=st.data())
 def test_arange(start, dtype, data):
     stop = data.draw(reals() | st.none(), label="stop")
     if stop is None:
@@ -64,7 +60,7 @@ def test_arange(start, dtype, data):
         _stop = data.draw(reals(), label="stop")
         stop = _stop
 
-    tol = abs(_stop - _start) / (MAX_ARRAY_SIZE - 1)
+    tol = abs(_stop - _start) / (hh.MAX_ARRAY_SIZE - 1)
     assume(-tol > int_min)
     assume(tol < int_max)
     step = data.draw(
@@ -103,9 +99,9 @@ def test_arange(start, dtype, data):
     else:
         elements = []
     size = len(elements)
-    assert size <= MAX_ARRAY_SIZE, f"{size=}, should be no more than {MAX_ARRAY_SIZE=}"
+    assert size <= hh.MAX_ARRAY_SIZE, f"{size=}, should be no more than {hh.MAX_ARRAY_SIZE=}"
 
-    out = arange(start, stop=stop, step=step, dtype=dtype)
+    out = xp.arange(start, stop=stop, step=step, dtype=dtype)
 
     if dtype is None:
         if all_int:
@@ -126,11 +122,11 @@ def test_arange(start, dtype, data):
         #     [0.0, 0.33, 0.66, 1.0, 1.33, 1.66]
         #
         assert out.size in (size - 1, size, size + 1)
-    # TODO test elements
+    assume(out.size == size)
 
-@given(shapes(), kwargs(dtype=st.none() | shared_dtypes))
+@given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.shared_dtypes))
 def test_empty(shape, kw):
-    out = empty(shape, **kw)
+    out = xp.empty(shape, **kw)
     dtype = kw.get("dtype", None) or xp.float64
     if kw.get("dtype", None) is None:
         assert dh.is_float_dtype(out.dtype), f"empty() returned an array with dtype {out.dtype}, but should be the default float dtype"
@@ -142,11 +138,11 @@ def test_empty(shape, kw):
 
 
 @given(
-    x=xps.arrays(dtype=xps.scalar_dtypes(), shape=shapes()),
-    kw=kwargs(dtype=st.none() | xps.scalar_dtypes())
+    x=xps.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()),
+    kw=hh.kwargs(dtype=st.none() | xps.scalar_dtypes())
 )
 def test_empty_like(x, kw):
-    out = empty_like(x, **kw)
+    out = xp.empty_like(x, **kw)
     dtype = kw.get("dtype", None) or x.dtype
     if kw.get("dtype", None) is None:
         assert out.dtype == x.dtype, f"{x.dtype=!s}, but empty_like() returned an array with dtype {out.dtype}"
@@ -155,18 +151,18 @@ def test_empty_like(x, kw):
     assert out.shape == x.shape, f"{x.shape=}, but empty_like() returned an array with shape {out.shape}"
 
 
-# TODO: Use this method for xp.all optional arguments
+# TODO: Use this method for ah.all optional arguments
 optional_marker = object()
 
-@given(sqrt_sizes, st.one_of(st.just(optional_marker), st.none(), sqrt_sizes), st.one_of(st.none(), st.integers()), numeric_dtypes)
+@given(hh.sqrt_sizes, st.one_of(st.just(optional_marker), st.none(), hh.sqrt_sizes), st.one_of(st.none(), st.integers()), hh.numeric_dtypes)
 def test_eye(n_rows, n_cols, k, dtype):
     kwargs = {k: v for k, v in {'k': k, 'dtype': dtype}.items() if v
               is not None}
     if n_cols is optional_marker:
-        a = eye(n_rows, **kwargs)
+        a = xp.eye(n_rows, **kwargs)
         n_cols = None
     else:
-        a = eye(n_rows, n_cols, **kwargs)
+        a = xp.eye(n_rows, n_cols, **kwargs)
     if dtype is None:
         assert dh.is_float_dtype(a.dtype), "eye() should return an array with the default floating point dtype"
     else:
@@ -191,25 +187,25 @@ if dh.default_int == xp.int32:
     default_unsafe_dtypes.extend([xp.uint32, xp.int64])
 if dh.default_float == xp.float32:
     default_unsafe_dtypes.append(xp.float64)
-default_safe_scalar_dtypes: st.SearchStrategy = xps.scalar_dtypes().filter(
+default_safe_dtypes: st.SearchStrategy = xps.scalar_dtypes().filter(
     lambda d: d not in default_unsafe_dtypes
 )
 
 
 @st.composite
 def full_fill_values(draw):
-    kw = draw(st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw"))
-    dtype = kw.get("dtype", None) or draw(default_safe_scalar_dtypes)
+    kw = draw(st.shared(hh.kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw"))
+    dtype = kw.get("dtype", None) or draw(default_safe_dtypes)
     return draw(xps.from_dtype(dtype))
 
 
 @given(
-    shape=shapes(),
+    shape=hh.shapes(),
     fill_value=full_fill_values(),
-    kw=st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw"),
+    kw=st.shared(hh.kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw"),
 )
 def test_full(shape, fill_value, kw):
-    out = full(shape, fill_value, **kw)
+    out = xp.full(shape, fill_value, **kw)
     if kw.get("dtype", None):
         dtype = kw["dtype"]
     elif isinstance(fill_value, bool):
@@ -229,25 +225,25 @@ def test_full(shape, fill_value, kw):
         assert out.dtype == dtype
     assert out.shape == shape,  f"{shape=}, but full() returned an array with shape {out.shape}"
     if dh.is_float_dtype(out.dtype) and math.isnan(fill_value):
-        assert xp.all(isnan(out)), "full() array did not equal the fill value"
+        assert ah.all(ah.isnan(out)), "full() array did not equal the fill value"
     else:
-        assert xp.all(equal(out, asarray(fill_value, dtype=dtype))), "full() array did not equal the fill value"
+        assert ah.all(ah.equal(out, ah.asarray(fill_value, dtype=dtype))), "full() array did not equal the fill value"
 
 
 @st.composite
 def full_like_fill_values(draw):
-    kw = draw(st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_like_kw"))
-    dtype = kw.get("dtype", None) or draw(shared_dtypes)
+    kw = draw(st.shared(hh.kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_like_kw"))
+    dtype = kw.get("dtype", None) or draw(hh.shared_dtypes)
     return draw(xps.from_dtype(dtype))
 
 
 @given(
-    x=xps.arrays(dtype=shared_dtypes, shape=shapes()),
+    x=xps.arrays(dtype=hh.shared_dtypes, shape=hh.shapes()),
     fill_value=full_like_fill_values(),
-    kw=st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_like_kw"),
+    kw=st.shared(hh.kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_like_kw"),
 )
 def test_full_like(x, fill_value, kw):
-    out = full_like(x, fill_value, **kw)
+    out = xp.full_like(x, fill_value, **kw)
     dtype = kw.get("dtype", None) or x.dtype
     if kw.get("dtype", None) is None:
         assert out.dtype == x.dtype, f"{x.dtype=!s}, but full_like() returned an array with dtype {out.dtype}"
@@ -255,27 +251,27 @@ def test_full_like(x, fill_value, kw):
         assert out.dtype == dtype, f"{dtype=!s}, but full_like() returned an array with dtype {out.dtype}"
     assert out.shape == x.shape, "{x.shape=}, but full_like() returned an array with shape {out.shape}"
     if dh.is_float_dtype(dtype) and math.isnan(fill_value):
-        assert xp.all(isnan(out)), "full_like() array did not equal the fill value"
+        assert ah.all(ah.isnan(out)), "full_like() array did not equal the fill value"
     else:
-        assert xp.all(equal(out, asarray(fill_value, dtype=dtype))), "full_like() array did not equal the fill value"
+        assert ah.all(ah.equal(out, ah.asarray(fill_value, dtype=dtype))), "full_like() array did not equal the fill value"
 
 
-@given(scalars(shared_dtypes, finite=True),
-       scalars(shared_dtypes, finite=True),
-       sizes,
-       st.one_of(st.none(), shared_dtypes),
+@given(hh.scalars(hh.shared_dtypes, finite=True),
+       hh.scalars(hh.shared_dtypes, finite=True),
+       hh.sizes,
+       st.one_of(st.none(), hh.shared_dtypes),
        st.one_of(st.none(), st.booleans()),)
 def test_linspace(start, stop, num, dtype, endpoint):
     # Skip on int start or stop that cannot be exactly represented as a float,
     # since we do not have good approx_equal helpers yet.
     if ((dtype is None or dh.is_float_dtype(dtype))
-        and ((isinstance(start, int) and not isintegral(asarray(start, dtype=dtype)))
-             or (isinstance(stop, int) and not isintegral(asarray(stop, dtype=dtype))))):
+        and ((isinstance(start, int) and not ah.isintegral(xp.asarray(start, dtype=dtype)))
+             or (isinstance(stop, int) and not ah.isintegral(xp.asarray(stop, dtype=dtype))))):
         assume(False)
 
     kwargs = {k: v for k, v in {'dtype': dtype, 'endpoint': endpoint}.items()
               if v is not None}
-    a = linspace(start, stop, num, **kwargs)
+    a = xp.linspace(start, stop, num, **kwargs)
 
     if dtype is None:
         assert dh.is_float_dtype(a.dtype), "linspace() should return an array with the default floating point dtype"
@@ -286,26 +282,26 @@ def test_linspace(start, stop, num, dtype, endpoint):
 
     if endpoint in [None, True]:
         if num > 1:
-            assert xp.all(equal(a[-1], asarray(stop, dtype=a.dtype))), "linspace() produced an array that does not include the endpoint"
+            assert ah.all(ah.equal(a[-1], ah.asarray(stop, dtype=a.dtype))), "linspace() produced an array that does not include the endpoint"
     else:
         # linspace(..., num, endpoint=False) is the same as the first num
         # elements of linspace(..., num+1, endpoint=True)
-        b = linspace(start, stop, num + 1, **{**kwargs, 'endpoint': True})
-        assert_exactly_equal(b[:-1], a)
+        b = xp.linspace(start, stop, num + 1, **{**kwargs, 'endpoint': True})
+        ah.assert_exactly_equal(b[:-1], a)
 
     if num > 0:
         # We need to cast start to dtype
-        assert xp.all(equal(a[0], asarray(start, dtype=a.dtype))), "linspace() produced an array that does not start with the start"
+        assert ah.all(ah.equal(a[0], ah.asarray(start, dtype=a.dtype))), "xp.linspace() produced an array that does not start with the start"
 
         # TODO: This requires an assert_approx_equal function
 
         # n = num - 1 if endpoint in [None, True] else num
         # for i in range(1, num):
-        #     assert xp.all(equal(a[i], full((), i*(stop - start)/n + start, dtype=dtype))), f"linspace() produced an array with an incorrect value at index {i}"
+        #     assert ah.all(ah.equal(a[i], ah.full((), i*(stop - start)/n + start, dtype=dtype))), f"linspace() produced an array with an incorrect value at index {i}"
 
 
 def make_one(dtype):
-    if kwargs is None or dh.is_float_dtype(dtype):
+    if dtype is None or dh.is_float_dtype(dtype):
         return 1.0
     elif dh.is_int_dtype(dtype):
         return 1
@@ -313,35 +309,35 @@ def make_one(dtype):
         return True
 
 
-@given(shapes(), kwargs(dtype=st.none() | xps.scalar_dtypes()))
+@given(hh.shapes(), hh.kwargs(dtype=st.none() | xps.scalar_dtypes()))
 def test_ones(shape, kw):
-    out = ones(shape, **kw)
+    out = xp.ones(shape, **kw)
     dtype = kw.get("dtype", None) or xp.float64
     if kw.get("dtype", None) is None:
         assert dh.is_float_dtype(out.dtype), f"ones() returned an array with dtype {out.dtype}, but should be the default float dtype"
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but ones() returned an array with dtype {out.dtype}"
     assert out.shape == shape, f"{shape=}, but empty() returned an array with shape {out.shape}"
-    assert xp.all(equal(out, asarray(make_one(dtype), dtype=dtype))), "ones() array did not equal 1"
+    assert ah.all(ah.equal(out, ah.asarray(make_one(dtype), dtype=dtype))), "ones() array did not equal 1"
 
 
 @given(
-    x=xps.arrays(dtype=dtypes, shape=shapes()),
-    kw=kwargs(dtype=st.none() | xps.scalar_dtypes()),
+    x=xps.arrays(dtype=hh.dtypes, shape=hh.shapes()),
+    kw=hh.kwargs(dtype=st.none() | xps.scalar_dtypes()),
 )
 def test_ones_like(x, kw):
-    out = ones_like(x, **kw)
+    out = xp.ones_like(x, **kw)
     dtype = kw.get("dtype", None) or x.dtype
     if kw.get("dtype", None) is None:
         assert out.dtype == x.dtype, f"{x.dtype=!s}, but ones_like() returned an array with dtype {out.dtype}"
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but ones_like() returned an array with dtype {out.dtype}"
     assert out.shape == x.shape, "{x.shape=}, but ones_like() returned an array with shape {out.shape}"
-    assert xp.all(equal(out, asarray(make_one(dtype), dtype=dtype))), "ones_like() array elements did not equal 1"
+    assert ah.all(ah.equal(out, ah.asarray(make_one(dtype), dtype=dtype))), "ones_like() array elements did not equal 1"
 
 
 def make_zero(dtype):
-    if dh.is_float_dtype(dtype):
+    if dtype is None or dh.is_float_dtype(dtype):
         return 0.0
     elif dh.is_int_dtype(dtype):
         return 0
@@ -349,29 +345,29 @@ def make_zero(dtype):
         return False
 
 
-@given(shapes(), kwargs(dtype=st.none() | xps.scalar_dtypes()))
+@given(hh.shapes(), hh.kwargs(dtype=st.none() | xps.scalar_dtypes()))
 def test_zeros(shape, kw):
-    out = zeros(shape, **kw)
+    out = xp.zeros(shape, **kw)
     dtype = kw.get("dtype", None) or xp.float64
     if kw.get("dtype", None) is None:
         assert dh.is_float_dtype(out.dtype), "zeros() returned an array with dtype {out.dtype}, but should be the default float dtype"
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but zeros() returned an array with dtype {out.dtype}"
     assert out.shape == shape, "zeros() produced an array with incorrect shape"
-    assert xp.all(equal(out, asarray(make_zero(dtype), dtype=dtype))), "zeros() array did not equal 0"
+    assert ah.all(ah.equal(out, ah.asarray(make_zero(dtype), dtype=dtype))), "zeros() array did not equal 0"
 
 
 @given(
-    x=xps.arrays(dtype=dtypes, shape=shapes()),
-    kw=kwargs(dtype=st.none() | xps.scalar_dtypes()),
+    x=xps.arrays(dtype=hh.dtypes, shape=hh.shapes()),
+    kw=hh.kwargs(dtype=st.none() | xps.scalar_dtypes()),
 )
 def test_zeros_like(x, kw):
-    out = zeros_like(x, **kw)
+    out = xp.zeros_like(x, **kw)
     dtype = kw.get("dtype", None) or x.dtype
     if kw.get("dtype", None) is None:
-        assert out.dtype == x.dtype, f"{x.dtype=!s}, but zeros_like() returned an array with dtype {out.dtype}"
+        assert out.dtype == x.dtype, f"{x.dtype=!s}, but xp.zeros_like() returned an array with dtype {out.dtype}"
     else:
-        assert out.dtype == dtype, f"{dtype=!s}, but zeros_like() returned an array with dtype {out.dtype}"
-    assert out.shape == x.shape, "{x.shape=}, but zeros_like() returned an array with shape {out.shape}"
-    assert xp.all(equal(out, asarray(make_zero(dtype), dtype=out.dtype))), "zeros_like() array elements did not xp.all equal 0"
+        assert out.dtype == dtype, f"{dtype=!s}, but xp.zeros_like() returned an array with dtype {out.dtype}"
+    assert out.shape == x.shape, "{x.shape=}, but xp.zeros_like() returned an array with shape {out.shape}"
+    assert ah.all(ah.equal(out, ah.asarray(make_zero(dtype), dtype=out.dtype))), "xp.zeros_like() array elements did not ah.all xp.equal 0"
 

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -1,7 +1,9 @@
 import math
+from typing import Union
+from itertools import takewhile, count
 
-from ._array_module import (asarray, arange, ceil, empty, empty_like, eye, full,
-                            full_like, equal, all, linspace, ones, ones_like,
+from ._array_module import (asarray, arange, empty, empty_like, eye, full,
+                            full_like, equal, linspace, ones, ones_like,
                             zeros, zeros_like, isnan)
 from . import _array_module as xp
 from .array_helpers import assert_exactly_equal, isintegral
@@ -11,66 +13,100 @@ from .hypothesis_helpers import (numeric_dtypes, dtypes, MAX_ARRAY_SIZE,
 from . import dtype_helpers as dh
 from . import xps
 
-from hypothesis import assume, given
-from hypothesis.strategies import integers, floats, one_of, none, booleans, just, shared, composite, SearchStrategy
+from hypothesis import assume, given, strategies as st
 
 
-int_range = integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE)
-float_range = floats(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE,
-                     allow_nan=False)
-@given(one_of(int_range, float_range),
-       one_of(none(), int_range, float_range),
-       one_of(none(), int_range, float_range).filter(lambda x: x != 0
-                                                     and (abs(x) > 0.01 if isinstance(x, float) else True)),
-       one_of(none(), numeric_dtypes))
-def test_arange(start, stop, step, dtype):
-    if dtype in dh.dtype_ranges:
-        m, M = dh.dtype_ranges[dtype]
-        if (not (m <= start <= M)
-            or isinstance(stop, int) and not (m <= stop <= M)
-            or isinstance(step, int) and not (m <= step <= M)):
-            assume(False)
+int_min, int_max = dh.dtype_ranges[dh.default_int]
+float_min = float(int_min * (MAX_ARRAY_SIZE - 1))
+float_max = float(int_max * (MAX_ARRAY_SIZE - 1))
 
-    kwargs = {} if dtype is None else {'dtype': dtype}
 
-    all_int = (dh.is_int_dtype(dtype)
-               and isinstance(start, int)
-               and (stop is None or isinstance(stop, int))
-               and (step is None or isinstance(step, int)))
+def reals(min_value=None, max_value=None) -> st.SearchStrategy[Union[int, float]]:
+    round_ = int
+    if min_value is not None and min_value > 0:
+        round_ = math.ceil
+    elif max_value is not None and max_value < 0:
+        round_ = math.floor
+    int_min_value = int_min if min_value is None else max(round_(min_value), int_min)
+    int_max_value = int_max if max_value is None else min(round_(max_value), int_max)
 
-    if stop is None:
-        # NB: "start" is really the stop
-        # step is ignored in this case
-        a = arange(start, **kwargs)
-        if all_int:
-            r = range(start)
-    elif step is None:
-        a = arange(start, stop, **kwargs)
-        if all_int:
-            r = range(start, stop)
+    float_min_value = float_min if min_value is None else max(min_value, float_min)
+    float_max_value = float_max if max_value is None else min(max_value, float_max)
+
+    return st.one_of(
+        st.integers(int_min_value, int_max_value),
+        st.floats(float_min_value, float_max_value, allow_nan=False, allow_infinity=False)
+    )
+
+@given(start=reals(), dtype=st.none() | numeric_dtypes, data=st.data())
+def test_arange(start, dtype, data):
+    if data.draw(st.booleans(), label="stop is None"):
+        _start = 0
+        _stop = start
+        stop = None
     else:
-        a = arange(start, stop, step, **kwargs)
-        if all_int:
-            r = range(start, stop, step)
+        _start = start
+        _stop = data.draw(reals(), label="stop")
+        stop = _stop
+
+    tol = abs(_stop - _start) / (MAX_ARRAY_SIZE - 1)
+    assume(-tol > int_min)
+    assume(tol < int_max)
+    if _stop - _start > 0:
+        step_strat = reals(min_value=tol).filter(lambda n: n != 0)
+    else:
+        step_strat = reals(max_value=-tol).filter(lambda n: n != 0)
+    step = data.draw(step_strat, label="step")
+
+    all_int = all(arg is None or isinstance(arg, int) for arg in [start, stop, step])
+
     if dtype is None:
-        # TODO: What is the correct dtype of a?
-        pass
+        if all_int:
+            _dtype = dh.default_int
+        else:
+            _dtype = dh.default_float
     else:
-        assert a.dtype == dtype, "arange() produced an incorrect dtype"
-    assert a.ndim == 1, "arange() should return a 1-dimensional array"
-    if all_int:
-        assert a.shape == (len(r),), "arange() produced incorrect shape"
-        if len(r) <= MAX_ARRAY_SIZE:
-            assert list(a) == list(r), "arange() produced incorrect values"
-    else:
-        # This is already implied by the len(r) test above
-        if (stop is not None
-            and step is not None
-            and (step > 0 and stop >= start
-                 or step < 0 and stop <= start)):
-            assert a.size == ceil(asarray((stop-start)/step)), "arange() produced an array of the incorrect size"
+        _dtype = dtype
 
-@given(shapes(), kwargs(dtype=none() | shared_dtypes))
+    if dh.is_int_dtype(_dtype):
+        m, M = dh.dtype_ranges[_dtype]
+        assume(m <= _start <= M)
+        assume(m <= _stop <= M)
+        assume(m <= step <= M)
+
+    if step > 0:
+        condition = lambda x: x < _stop
+    else:
+        condition = lambda x: x > _stop
+    scalar_type = int if dh.is_int_dtype(_dtype) else float
+    elements = list(scalar_type(n) for n in takewhile(condition, count(_start, step)))
+    size = len(elements)
+    assert size < MAX_ARRAY_SIZE, f"{size=}, should be below {MAX_ARRAY_SIZE=}"
+
+    out = arange(start, stop=stop, step=step, dtype=dtype)
+
+    if dtype is None:
+        if all_int:
+            assert dh.is_int_dtype(out.dtype)
+        else:
+            assert dh.is_float_dtype(out.dtype)
+    else:
+        assert out.dtype == dtype
+    assert out.ndim == 1
+    if dh.is_int_dtype(step):
+        assert out.size == size
+    else:
+        # We check size is roughly as expected to avoid edge cases e.g.
+        #
+        #     >>> xp.arange(2, step=0.333333333333333)
+        #     [0.0, 0.33, 0.66, 1.0, 1.33, 1.66, 2.0]
+        #     >>> xp.arange(2, step=0.3333333333333333)
+        #     [0.0, 0.33, 0.66, 1.0, 1.33, 1.66]
+        #
+        assert out.size in (size - 1, size, size + 1)
+    # TODO test elements
+
+@given(shapes(), kwargs(dtype=st.none() | shared_dtypes))
 def test_empty(shape, kw):
     out = empty(shape, **kw)
     dtype = kw.get("dtype", None) or xp.float64
@@ -85,7 +121,7 @@ def test_empty(shape, kw):
 
 @given(
     x=xps.arrays(dtype=xps.scalar_dtypes(), shape=shapes()),
-    kw=kwargs(dtype=none() | xps.scalar_dtypes())
+    kw=kwargs(dtype=st.none() | xps.scalar_dtypes())
 )
 def test_empty_like(x, kw):
     out = empty_like(x, **kw)
@@ -97,10 +133,10 @@ def test_empty_like(x, kw):
     assert out.shape == x.shape, f"{x.shape=}, but empty_like() returned an array with shape {out.shape}"
 
 
-# TODO: Use this method for all optional arguments
+# TODO: Use this method for xp.all optional arguments
 optional_marker = object()
 
-@given(sqrt_sizes, one_of(just(optional_marker), none(), sqrt_sizes), one_of(none(), integers()), numeric_dtypes)
+@given(sqrt_sizes, st.one_of(st.just(optional_marker), st.none(), sqrt_sizes), st.one_of(st.none(), st.integers()), numeric_dtypes)
 def test_eye(n_rows, n_cols, k, dtype):
     kwargs = {k: v for k, v in {'k': k, 'dtype': dtype}.items() if v
               is not None}
@@ -133,14 +169,14 @@ if dh.default_int == xp.int32:
     default_unsafe_dtypes.extend([xp.uint32, xp.int64])
 if dh.default_float == xp.float32:
     default_unsafe_dtypes.append(xp.float64)
-default_safe_scalar_dtypes: SearchStrategy = xps.scalar_dtypes().filter(
+default_safe_scalar_dtypes: st.SearchStrategy = xps.scalar_dtypes().filter(
     lambda d: d not in default_unsafe_dtypes
 )
 
 
-@composite
+@st.composite
 def full_fill_values(draw):
-    kw = draw(shared(kwargs(dtype=none() | xps.scalar_dtypes()), key="full_kw"))
+    kw = draw(st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw"))
     dtype = kw.get("dtype", None) or draw(default_safe_scalar_dtypes)
     return draw(xps.from_dtype(dtype))
 
@@ -148,7 +184,7 @@ def full_fill_values(draw):
 @given(
     shape=shapes(),
     fill_value=full_fill_values(),
-    kw=shared(kwargs(dtype=none() | xps.scalar_dtypes()), key="full_kw"),
+    kw=st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw"),
 )
 def test_full(shape, fill_value, kw):
     out = full(shape, fill_value, **kw)
@@ -171,14 +207,14 @@ def test_full(shape, fill_value, kw):
         assert out.dtype == dtype
     assert out.shape == shape,  f"{shape=}, but full() returned an array with shape {out.shape}"
     if dh.is_float_dtype(out.dtype) and math.isnan(fill_value):
-        assert all(isnan(out)), "full() array did not equal the fill value"
+        assert xp.all(isnan(out)), "full() array did not equal the fill value"
     else:
-        assert all(equal(out, asarray(fill_value, dtype=dtype))), "full() array did not equal the fill value"
+        assert xp.all(equal(out, asarray(fill_value, dtype=dtype))), "full() array did not equal the fill value"
 
 
-@composite
+@st.composite
 def full_like_fill_values(draw):
-    kw = draw(shared(kwargs(dtype=none() | xps.scalar_dtypes()), key="full_like_kw"))
+    kw = draw(st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_like_kw"))
     dtype = kw.get("dtype", None) or draw(shared_dtypes)
     return draw(xps.from_dtype(dtype))
 
@@ -186,7 +222,7 @@ def full_like_fill_values(draw):
 @given(
     x=xps.arrays(dtype=shared_dtypes, shape=shapes()),
     fill_value=full_like_fill_values(),
-    kw=shared(kwargs(dtype=none() | xps.scalar_dtypes()), key="full_like_kw"),
+    kw=st.shared(kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_like_kw"),
 )
 def test_full_like(x, fill_value, kw):
     out = full_like(x, fill_value, **kw)
@@ -197,16 +233,16 @@ def test_full_like(x, fill_value, kw):
         assert out.dtype == dtype, f"{dtype=!s}, but full_like() returned an array with dtype {out.dtype}"
     assert out.shape == x.shape, "{x.shape=}, but full_like() returned an array with shape {out.shape}"
     if dh.is_float_dtype(dtype) and math.isnan(fill_value):
-        assert all(isnan(out)), "full_like() array did not equal the fill value"
+        assert xp.all(isnan(out)), "full_like() array did not equal the fill value"
     else:
-        assert all(equal(out, asarray(fill_value, dtype=dtype))), "full_like() array did not equal the fill value"
+        assert xp.all(equal(out, asarray(fill_value, dtype=dtype))), "full_like() array did not equal the fill value"
 
 
 @given(scalars(shared_dtypes, finite=True),
        scalars(shared_dtypes, finite=True),
        sizes,
-       one_of(none(), shared_dtypes),
-       one_of(none(), booleans()),)
+       st.one_of(st.none(), shared_dtypes),
+       st.one_of(st.none(), st.booleans()),)
 def test_linspace(start, stop, num, dtype, endpoint):
     # Skip on int start or stop that cannot be exactly represented as a float,
     # since we do not have good approx_equal helpers yet.
@@ -228,7 +264,7 @@ def test_linspace(start, stop, num, dtype, endpoint):
 
     if endpoint in [None, True]:
         if num > 1:
-            assert all(equal(a[-1], full((), stop, dtype=a.dtype))), "linspace() produced an array that does not include the endpoint"
+            assert xp.all(equal(a[-1], asarray(stop, dtype=a.dtype))), "linspace() produced an array that does not include the endpoint"
     else:
         # linspace(..., num, endpoint=False) is the same as the first num
         # elements of linspace(..., num+1, endpoint=True)
@@ -237,13 +273,13 @@ def test_linspace(start, stop, num, dtype, endpoint):
 
     if num > 0:
         # We need to cast start to dtype
-        assert all(equal(a[0], full((), start, dtype=a.dtype))), "linspace() produced an array that does not start with the start"
+        assert xp.all(equal(a[0], asarray(start, dtype=a.dtype))), "linspace() produced an array that does not start with the start"
 
         # TODO: This requires an assert_approx_equal function
 
         # n = num - 1 if endpoint in [None, True] else num
         # for i in range(1, num):
-        #     assert all(equal(a[i], full((), i*(stop - start)/n + start, dtype=dtype))), f"linspace() produced an array with an incorrect value at index {i}"
+        #     assert xp.all(equal(a[i], full((), i*(stop - start)/n + start, dtype=dtype))), f"linspace() produced an array with an incorrect value at index {i}"
 
 
 def make_one(dtype):
@@ -255,7 +291,7 @@ def make_one(dtype):
         return True
 
 
-@given(shapes(), kwargs(dtype=none() | xps.scalar_dtypes()))
+@given(shapes(), kwargs(dtype=st.none() | xps.scalar_dtypes()))
 def test_ones(shape, kw):
     out = ones(shape, **kw)
     dtype = kw.get("dtype", None) or xp.float64
@@ -264,12 +300,12 @@ def test_ones(shape, kw):
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but ones() returned an array with dtype {out.dtype}"
     assert out.shape == shape, f"{shape=}, but empty() returned an array with shape {out.shape}"
-    assert all(equal(out, full((), make_one(dtype), dtype=dtype))), "ones() array did not equal 1"
+    assert xp.all(equal(out, asarray(make_one(dtype), dtype=dtype))), "ones() array did not equal 1"
 
 
 @given(
     x=xps.arrays(dtype=dtypes, shape=shapes()),
-    kw=kwargs(dtype=none() | xps.scalar_dtypes()),
+    kw=kwargs(dtype=st.none() | xps.scalar_dtypes()),
 )
 def test_ones_like(x, kw):
     out = ones_like(x, **kw)
@@ -279,7 +315,7 @@ def test_ones_like(x, kw):
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but ones_like() returned an array with dtype {out.dtype}"
     assert out.shape == x.shape, "{x.shape=}, but ones_like() returned an array with shape {out.shape}"
-    assert all(equal(out, full((), make_one(dtype), dtype=dtype))), "ones_like() array elements did not equal 1"
+    assert xp.all(equal(out, asarray(make_one(dtype), dtype=dtype))), "ones_like() array elements did not equal 1"
 
 
 def make_zero(dtype):
@@ -291,7 +327,7 @@ def make_zero(dtype):
         return False
 
 
-@given(shapes(), kwargs(dtype=none() | xps.scalar_dtypes()))
+@given(shapes(), kwargs(dtype=st.none() | xps.scalar_dtypes()))
 def test_zeros(shape, kw):
     out = zeros(shape, **kw)
     dtype = kw.get("dtype", None) or xp.float64
@@ -300,12 +336,12 @@ def test_zeros(shape, kw):
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but zeros() returned an array with dtype {out.dtype}"
     assert out.shape == shape, "zeros() produced an array with incorrect shape"
-    assert all(equal(out, full((), make_zero(dtype), dtype=dtype))), "zeros() array did not equal 0"
+    assert xp.all(equal(out, asarray(make_zero(dtype), dtype=dtype))), "zeros() array did not equal 0"
 
 
 @given(
     x=xps.arrays(dtype=dtypes, shape=shapes()),
-    kw=kwargs(dtype=none() | xps.scalar_dtypes()),
+    kw=kwargs(dtype=st.none() | xps.scalar_dtypes()),
 )
 def test_zeros_like(x, kw):
     out = zeros_like(x, **kw)
@@ -315,5 +351,5 @@ def test_zeros_like(x, kw):
     else:
         assert out.dtype == dtype, f"{dtype=!s}, but zeros_like() returned an array with dtype {out.dtype}"
     assert out.shape == x.shape, "{x.shape=}, but zeros_like() returned an array with shape {out.shape}"
-    assert all(equal(out, full((), make_zero(dtype), dtype=out.dtype))), "zeros_like() array elements did not all equal 0"
+    assert xp.all(equal(out, asarray(make_zero(dtype), dtype=out.dtype))), "zeros_like() array elements did not xp.all equal 0"
 

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -123,6 +123,10 @@ def test_arange(start, dtype, data):
         #
         assert out.size in (size - 1, size, size + 1)
     assume(out.size == size)
+    if dh.is_int_dtype(_dtype):
+        ah.assert_exactly_equal(out, ah.asarray(elements, dtype=_dtype))
+    else:
+        pass # TODO: either emulate array module behaviour or assert a rough equals
 
 @given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.shared_dtypes))
 def test_empty(shape, kw):

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -54,7 +54,8 @@ def reals(min_value=None, max_value=None) -> st.SearchStrategy[Union[int, float]
 
 @given(start=reals(), dtype=st.none() | numeric_dtypes, data=st.data())
 def test_arange(start, dtype, data):
-    if data.draw(st.booleans(), label="stop is None"):
+    stop = data.draw(reals() | st.none(), label="stop")
+    if stop is None:
         _start = 0
         _stop = start
         stop = None

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -231,12 +231,14 @@ def test_eye(n_rows, n_cols, kw):
         assert_kw_dtype("eye", kw["dtype"], out.dtype)
     _n_cols = n_rows if n_cols is None else n_cols
     assert_shape("eye", out.shape, (n_rows, _n_cols), n_rows=n_rows, n_cols=n_cols)
+    f_func = f"[eye({n_rows=}, {n_cols=})]"
     for i in range(n_rows):
         for j in range(_n_cols):
+            f_indexed_out = f"out[{i}, {j}]={out[i, j]}"
             if j - i == kw.get("k", 0):
-                assert out[i, j] == 1, f"out[{i}, {j}]={out[i, j]}, should be 1 [eye()]"
+                assert out[i, j] == 1, f"{f_indexed_out}, should be 1 {f_func}"
             else:
-                assert out[i, j] == 0, f"out[{i}, {j}]={out[i, j]}, should be 0 [eye()]"
+                assert out[i, j] == 0, f"{f_indexed_out}, should be 0 {f_func}"
 
 
 default_unsafe_dtypes = [xp.uint64]

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -10,7 +10,7 @@ from . import hypothesis_helpers as hh
 from . import dtype_helpers as dh
 from . import pytest_helpers as ph
 from . import xps
-from .typing import Shape, DataType, Array
+from .typing import Shape, DataType, Array, Scalar
 
 
 def assert_default_float(func_name: str, dtype: DataType):
@@ -43,7 +43,9 @@ def assert_kw_dtype(func_name: str, kw_dtype: DataType, out_dtype: DataType):
     assert out_dtype == kw_dtype, msg
 
 
-def assert_shape(func_name: str, out_shape: Shape, expected: Union[int, Shape], **kw):
+def assert_shape(
+    func_name: str, out_shape: Shape, expected: Union[int, Shape], /, **kw
+):
     f_kw = ", ".join(f"{k}={v}" for k, v in kw.items())
     msg = f"out.shape={out_shape}, but should be {expected} [{func_name}({f_kw})]"
     if isinstance(expected, int):
@@ -51,13 +53,15 @@ def assert_shape(func_name: str, out_shape: Shape, expected: Union[int, Shape], 
     assert out_shape == expected, msg
 
 
-def assert_fill(func_name: str, fill: float, dtype: DataType, out: Array, **kw):
+def assert_fill(
+    func_name: str, fill_value: Scalar, dtype: DataType, out: Array, /, **kw
+):
     f_kw = ", ".join(f"{k}={v}" for k, v in kw.items())
-    msg = f"out not filled with {fill} [{func_name}({f_kw})]\n" f"{out=}"
-    if math.isnan(fill):
+    msg = f"out not filled with {fill_value} [{func_name}({f_kw})]\n" f"{out=}"
+    if math.isnan(fill_value):
         assert ah.all(ah.isnan(out)), msg
     else:
-        assert ah.all(ah.equal(out, ah.asarray(fill, dtype=dtype))), msg
+        assert ah.all(ah.equal(out, ah.asarray(fill_value, dtype=dtype))), msg
 
 
 # Testing xp.arange() requires bounding the start/stop/step arguments to only
@@ -375,7 +379,7 @@ def test_linspace(num, dtype, endpoint, data):
         # TODO: array assertions ala test_arange
 
 
-def make_one(dtype: DataType) -> Union[bool, float]:
+def make_one(dtype: DataType) -> Scalar:
     if dtype is None or dh.is_float_dtype(dtype):
         return 1.0
     elif dh.is_int_dtype(dtype):
@@ -411,7 +415,7 @@ def test_ones_like(x, kw):
     assert_fill("ones_like", make_one(dtype), dtype, out)
 
 
-def make_zero(dtype: DataType) -> Union[bool, float]:
+def make_zero(dtype: DataType) -> Scalar:
     if dtype is None or dh.is_float_dtype(dtype):
         return 0.0
     elif dh.is_int_dtype(dtype):

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -228,7 +228,7 @@ def test_arange(dtype, data):
         #     [0.0, 0.33, 0.66, 1.0, 1.33, 1.66]
         #
         min_size = math.floor(size * 0.9)
-        max_size = math.ceil(size * 1.1)
+        max_size = max(math.ceil(size * 1.1), 1)
         assert (
             min_size <= out.size <= max_size
         ), f"{out.size=}, but should be roughly {size} {f_func}"

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -147,9 +147,9 @@ def test_arange(dtype, data):
         else:
             ph.assert_default_float("arange", out.dtype)
     else:
-        assert out.dtype == dtype
+        ph.assert_dtype("arange", (out.dtype,), dtype)
     assert out.ndim == 1, f"{out.ndim=}, but should be 1 [linspace()]"
-    f_func = f"[arange({start=}, {stop=}, {step=})]"
+    f_func = f"[arange({start}, {stop}, {step})]"
     # We check size is roughly as expected to avoid edge cases e.g.
     #
     #     >>> xp.arange(2, step=0.333333333333333)
@@ -179,7 +179,7 @@ def test_arange(dtype, data):
         if out.size > 0:
             assert ah.equal(
                 out[0], ah.asarray(_start, dtype=out.dtype)
-            ), f"out[0]={out[0]}, but should be {_start} [arange({start=}, {stop=})]"
+            ), f"out[0]={out[0]}, but should be {_start} {f_func}"
 
 
 @given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.shared_dtypes))
@@ -353,8 +353,12 @@ def test_linspace(num, dtype, endpoint, data):
     )
     out = xp.linspace(start, stop, num, **kw)
 
+    if dtype is None:
+        ph.assert_default_float("linspace", out.dtype)
+    else:
+        ph.assert_dtype("linspace", (out.dtype,), dtype)
     ph.assert_shape("linspace", out.shape, num, start=stop, stop=stop, num=num)
-    f_func = f"[linspace({start=}, {stop=}, {num=})]"
+    f_func = f"[linspace({start}, {stop}, {num})]"
     if num > 0:
         assert ah.equal(
             out[0], ah.asarray(start, dtype=out.dtype)

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -164,7 +164,7 @@ def test_arange(dtype, data):
     else:
         assert out.dtype == dtype
     assert out.ndim == 1, f"{out.ndim=}, but should be 1 [linspace()]"
-    f_func = f"[linspace({start=}, {stop=}, {step=})]"
+    f_func = f"[arange({start=}, {stop=}, {step=})]"
     # We check size is roughly as expected to avoid edge cases e.g.
     #
     #     >>> xp.arange(2, step=0.333333333333333)
@@ -194,7 +194,7 @@ def test_arange(dtype, data):
         if out.size > 0:
             assert ah.equal(
                 out[0], ah.asarray(_start, dtype=out.dtype)
-            ), f"out[0]={out[0]}, but should be {_start} [linspace({start=}, {stop=})]"
+            ), f"out[0]={out[0]}, but should be {_start} [arange({start=}, {stop=})]"
 
 
 @given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.shared_dtypes))

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -1,6 +1,6 @@
 import math
 from itertools import count
-from typing import Any, Iterator, NamedTuple, Tuple, Union
+from typing import Iterator, NamedTuple, Union
 
 from hypothesis import assume, given
 from hypothesis import strategies as st
@@ -12,21 +12,6 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import xps
 from .typing import DataType, Scalar
-
-
-@st.composite
-def specified_kwargs(draw, *keys_values_defaults: Tuple[str, Any, Any]):
-    """Generates valid kwargs given expected defaults.
-
-    When we can't realistically use hh.kwargs() and thus test whether xp infact
-    defaults correctly, this strategy lets us remove generated arguments if they
-    are of the default value anyway.
-    """
-    kw = {}
-    for key, value, default in keys_values_defaults:
-        if value is not default or draw(st.booleans()):
-            kw[key] = value
-    return kw
 
 
 class frange(NamedTuple):
@@ -147,10 +132,10 @@ def test_arange(dtype, data):
     ), f"{size=} should be no more than {hh.MAX_ARRAY_SIZE}"  # sanity check
 
     kw = data.draw(
-        specified_kwargs(
-            ("stop", stop, None),
-            ("step", step, None),
-            ("dtype", dtype, None),
+        hh.specified_kwargs(
+            hh.KVD("stop", stop, None),
+            hh.KVD("step", step, None),
+            hh.KVD("dtype", dtype, None),
         ),
         label="kw",
     )
@@ -360,9 +345,9 @@ def test_linspace(num, dtype, endpoint, data):
             stop = data.draw(int_stops(start, num, _dtype, endpoint), label="stop")
 
     kw = data.draw(
-        specified_kwargs(
-            ("dtype", dtype, None),
-            ("endpoint", endpoint, True),
+        hh.specified_kwargs(
+            hh.KVD("dtype", dtype, None),
+            hh.KVD("endpoint", endpoint, True),
         ),
         label="kw",
     )

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -17,6 +17,7 @@ from . import _array_module as xp
 from . import array_helpers as ah
 from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
+from . import pytest_helpers as ph
 from . import xps
 # We might as well use this implementation rather than requiring
 # mod.broadcast_shapes(). See test_equal() and others.
@@ -32,6 +33,7 @@ def test_abs(x):
             mask = xp.not_equal(x, ah.full(x.shape, minval, dtype=x.dtype))
             x = x[mask]
     a = xp.abs(x)
+    ph.assert_shape("abs", a.shape, x.shape)
     assert ah.all(ah.logical_not(ah.negative_mathematical_sign(a))), "abs(x) did not have positive sign"
     less_zero = ah.negative_mathematical_sign(x)
     negx = ah.negative(x)
@@ -43,6 +45,7 @@ def test_abs(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_acos(x):
     a = xp.acos(x)
+    ph.assert_shape("acos", a.shape, x.shape)
     ONE = ah.one(x.shape, x.dtype)
     # Here (and elsewhere), should technically be a.dtype, but this is the
     # same as x.dtype, as tested by the type_promotion tests.
@@ -57,6 +60,7 @@ def test_acos(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_acosh(x):
     a = xp.acosh(x)
+    ph.assert_shape("acosh", a.shape, x.shape)
     ONE = ah.one(x.shape, x.dtype)
     INFINITY = ah.infinity(x.shape, x.dtype)
     ZERO = ah.zero(x.shape, x.dtype)
@@ -78,6 +82,7 @@ def test_add(x1, x2):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_asin(x):
     a = xp.asin(x)
+    ph.assert_shape("asin", a.shape, x.shape)
     ONE = ah.one(x.shape, x.dtype)
     PI = ah.π(x.shape, x.dtype)
     domain = ah.inrange(x, -ONE, ONE)
@@ -89,6 +94,7 @@ def test_asin(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_asinh(x):
     a = xp.asinh(x)
+    ph.assert_shape("asinh", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     domain = ah.inrange(x, -INFINITY, INFINITY)
     codomain = ah.inrange(a, -INFINITY, INFINITY)
@@ -99,6 +105,7 @@ def test_asinh(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_atan(x):
     a = xp.atan(x)
+    ph.assert_shape("atan", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     PI = ah.π(x.shape, x.dtype)
     domain = ah.inrange(x, -INFINITY, INFINITY)
@@ -145,6 +152,7 @@ def test_atan2(x1, x2):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_atanh(x):
     a = xp.atanh(x)
+    ph.assert_shape("atanh", a.shape, x.shape)
     ONE = ah.one(x.shape, x.dtype)
     INFINITY = ah.infinity(x.shape, x.dtype)
     domain = ah.inrange(x, -ONE, ONE)
@@ -159,7 +167,7 @@ def test_bitwise_and(x1, x2):
 
     # TODO: generate indices without broadcasting arrays (see test_equal comment)
     shape = broadcast_shapes(x1.shape, x2.shape)
-    assert out.shape == shape
+    ph.assert_shape("bitwise_and", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -186,7 +194,7 @@ def test_bitwise_left_shift(x1, x2):
 
     # TODO: generate indices without broadcasting arrays (see test_equal comment)
     shape = broadcast_shapes(x1.shape, x2.shape)
-    assert out.shape == shape
+    ph.assert_shape("bitwise_left_shift", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -203,6 +211,7 @@ def test_bitwise_left_shift(x1, x2):
 @given(xps.arrays(dtype=hh.integer_or_boolean_dtypes, shape=hh.shapes()))
 def test_bitwise_invert(x):
     out = xp.bitwise_invert(x)
+    ph.assert_shape("bitwise_invert", out.shape, x.shape)
     # Compare against the Python ~ operator.
     if out.dtype == xp.bool:
         for idx in ah.ndindex(out.shape):
@@ -223,7 +232,7 @@ def test_bitwise_or(x1, x2):
 
     # TODO: generate indices without broadcasting arrays (see test_equal comment)
     shape = broadcast_shapes(x1.shape, x2.shape)
-    assert out.shape == shape
+    ph.assert_shape("bitwise_or", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -250,7 +259,7 @@ def test_bitwise_right_shift(x1, x2):
 
     # TODO: generate indices without broadcasting arrays (see test_equal comment)
     shape = broadcast_shapes(x1.shape, x2.shape)
-    assert out.shape == shape
+    ph.assert_shape("bitwise_right_shift", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -269,7 +278,7 @@ def test_bitwise_xor(x1, x2):
 
     # TODO: generate indices without broadcasting arrays (see test_equal comment)
     shape = broadcast_shapes(x1.shape, x2.shape)
-    assert out.shape == shape
+    ph.assert_shape("bitwise_xor", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -293,6 +302,7 @@ def test_bitwise_xor(x1, x2):
 def test_ceil(x):
     # This test is almost identical to test_floor()
     a = xp.ceil(x)
+    ph.assert_shape("ceil", a.shape, x.shape)
     finite = ah.isfinite(x)
     ah.assert_integral(a[finite])
     assert ah.all(ah.less_equal(x[finite], a[finite]))
@@ -303,6 +313,7 @@ def test_ceil(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_cos(x):
     a = xp.cos(x)
+    ph.assert_shape("cos", a.shape, x.shape)
     ONE = ah.one(x.shape, x.dtype)
     INFINITY = ah.infinity(x.shape, x.dtype)
     domain = ah.inrange(x, -INFINITY, INFINITY, open=True)
@@ -314,6 +325,7 @@ def test_cos(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_cosh(x):
     a = xp.cosh(x)
+    ph.assert_shape("cosh", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     domain = ah.inrange(x, -INFINITY, INFINITY)
     codomain = ah.inrange(a, -INFINITY, INFINITY)
@@ -347,6 +359,7 @@ def test_equal(x1, x2):
     # indices to x1 and x2 that correspond to the broadcasted shapes. This
     # would avoid the dependence in this test on broadcast_to().
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("equal", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -382,6 +395,7 @@ def test_equal(x1, x2):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_exp(x):
     a = xp.exp(x)
+    ph.assert_shape("exp", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     ZERO = ah.zero(x.shape, x.dtype)
     domain = ah.inrange(x, -INFINITY, INFINITY)
@@ -393,6 +407,7 @@ def test_exp(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_expm1(x):
     a = xp.expm1(x)
+    ph.assert_shape("expm1", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     NEGONE = -ah.one(x.shape, x.dtype)
     domain = ah.inrange(x, -INFINITY, INFINITY)
@@ -405,6 +420,7 @@ def test_expm1(x):
 def test_floor(x):
     # This test is almost identical to test_ceil
     a = xp.floor(x)
+    ph.assert_shape("floor", a.shape, x.shape)
     finite = ah.isfinite(x)
     ah.assert_integral(a[finite])
     assert ah.all(ah.less_equal(a[finite], x[finite]))
@@ -442,6 +458,7 @@ def test_greater(x1, x2):
     # See the comments in test_equal() for a description of how this test
     # works.
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("greater", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -470,6 +487,7 @@ def test_greater_equal(x1, x2):
     # See the comments in test_equal() for a description of how this test
     # works.
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("greater_equal", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -494,9 +512,9 @@ def test_greater_equal(x1, x2):
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_isfinite(x):
     a = ah.isfinite(x)
-    TRUE = ah.true(x.shape)
+    ph.assert_shape("isfinite", a.shape, x.shape)
     if dh.is_int_dtype(x.dtype):
-        ah.assert_exactly_equal(a, TRUE)
+        ah.assert_exactly_equal(a, ah.true(x.shape))
     # Test that isfinite, isinf, and isnan are self-consistent.
     inf = ah.logical_or(xp.isinf(x), ah.isnan(x))
     ah.assert_exactly_equal(a, ah.logical_not(inf))
@@ -510,9 +528,11 @@ def test_isfinite(x):
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_isinf(x):
     a = xp.isinf(x)
-    FALSE = ah.false(x.shape)
+
+    ph.assert_shape("isinf", a.shape, x.shape)
+
     if dh.is_int_dtype(x.dtype):
-        ah.assert_exactly_equal(a, FALSE)
+        ah.assert_exactly_equal(a, ah.false(x.shape))
     finite_or_nan = ah.logical_or(ah.isfinite(x), ah.isnan(x))
     ah.assert_exactly_equal(a, ah.logical_not(finite_or_nan))
 
@@ -525,9 +545,11 @@ def test_isinf(x):
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_isnan(x):
     a = ah.isnan(x)
-    FALSE = ah.false(x.shape)
+
+    ph.assert_shape("isnan", a.shape, x.shape)
+
     if dh.is_int_dtype(x.dtype):
-        ah.assert_exactly_equal(a, FALSE)
+        ah.assert_exactly_equal(a, ah.false(x.shape))
     finite_or_inf = ah.logical_or(ah.isfinite(x), xp.isinf(x))
     ah.assert_exactly_equal(a, ah.logical_not(finite_or_inf))
 
@@ -544,6 +566,7 @@ def test_less(x1, x2):
     # See the comments in test_equal() for a description of how this test
     # works.
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("less", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -572,6 +595,7 @@ def test_less_equal(x1, x2):
     # See the comments in test_equal() for a description of how this test
     # works.
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("less_equal", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -596,6 +620,9 @@ def test_less_equal(x1, x2):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log(x):
     a = xp.log(x)
+
+    ph.assert_shape("log", a.shape, x.shape)
+
     INFINITY = ah.infinity(x.shape, x.dtype)
     ZERO = ah.zero(x.shape, x.dtype)
     domain = ah.inrange(x, ZERO, INFINITY)
@@ -607,6 +634,7 @@ def test_log(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log1p(x):
     a = xp.log1p(x)
+    ph.assert_shape("log1p", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     NEGONE = -ah.one(x.shape, x.dtype)
     codomain = ah.inrange(x, NEGONE, INFINITY)
@@ -618,6 +646,7 @@ def test_log1p(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log2(x):
     a = xp.log2(x)
+    ph.assert_shape("log2", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     ZERO = ah.zero(x.shape, x.dtype)
     domain = ah.inrange(x, ZERO, INFINITY)
@@ -629,6 +658,7 @@ def test_log2(x):
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log10(x):
     a = xp.log10(x)
+    ph.assert_shape("log10", a.shape, x.shape)
     INFINITY = ah.infinity(x.shape, x.dtype)
     ZERO = ah.zero(x.shape, x.dtype)
     domain = ah.inrange(x, ZERO, INFINITY)
@@ -650,6 +680,7 @@ def test_logical_and(x1, x2):
 
     # See the comments in test_equal
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("logical_and", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -659,7 +690,7 @@ def test_logical_and(x1, x2):
 @given(xps.arrays(dtype=xp.bool, shape=hh.shapes()))
 def test_logical_not(x):
     a = ah.logical_not(x)
-
+    ph.assert_shape("logical_not", a.shape, x.shape)
     for idx in ah.ndindex(x.shape):
         assert a[idx] == (not bool(x[idx]))
 
@@ -669,6 +700,7 @@ def test_logical_or(x1, x2):
 
     # See the comments in test_equal
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("logical_or", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -681,6 +713,7 @@ def test_logical_xor(x1, x2):
 
     # See the comments in test_equal
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("logical_xor", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -698,6 +731,8 @@ def test_multiply(x1, x2):
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_negative(x):
     out = ah.negative(x)
+
+    ph.assert_shape("negative", out.shape, x.shape)
 
     # Negation is an involution
     ah.assert_exactly_equal(x, ah.negative(out))
@@ -722,6 +757,7 @@ def test_not_equal(x1, x2):
     # See the comments in test_equal() for a description of how this test
     # works.
     shape = broadcast_shapes(x1.shape, x2.shape)
+    ph.assert_shape("not_equal", a.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
 
@@ -747,6 +783,7 @@ def test_not_equal(x1, x2):
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_positive(x):
     out = xp.positive(x)
+    ph.assert_shape("positive", out.shape, x.shape)
     # Positive does nothing
     ah.assert_exactly_equal(out, x)
 
@@ -773,6 +810,8 @@ def test_remainder(x1, x2):
 def test_round(x):
     a = xp.round(x)
 
+    ph.assert_shape("round", a.shape, x.shape)
+
     # Test that the res is integral
     finite = ah.isfinite(x)
     ah.assert_integral(a[finite])
@@ -794,28 +833,31 @@ def test_round(x):
 
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_sign(x):
-    # out = xp.sign(x)
-    pass
+    out = xp.sign(x)
+    ph.assert_shape("sign", out.shape, x.shape)
+    # TODO
 
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_sin(x):
-    # out = xp.sin(x)
-    pass
+    out = xp.sin(x)
+    ph.assert_shape("sin", out.shape, x.shape)
+    # TODO
 
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_sinh(x):
-    # out = xp.sinh(x)
-    pass
+    out = xp.sinh(x)
+    ph.assert_shape("sinh", out.shape, x.shape)
+    # TODO
 
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_square(x):
-    # out = xp.square(x)
-    pass
+    out = xp.square(x)
+    ph.assert_shape("square", out.shape, x.shape)
 
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_sqrt(x):
-    # out = xp.sqrt(x)
-    pass
+    out = xp.sqrt(x)
+    ph.assert_shape("sqrt", out.shape, x.shape)
 
 @given(*hh.two_mutual_arrays(dh.numeric_dtypes))
 def test_subtract(x1, x2):
@@ -824,21 +866,22 @@ def test_subtract(x1, x2):
 
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_tan(x):
-    # out = xp.tan(x)
-    pass
+    out = xp.tan(x)
+    ph.assert_shape("tan", out.shape, x.shape)
+    # TODO
 
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_tanh(x):
-    # out = xp.tanh(x)
-    pass
+    out = xp.tanh(x)
+    ph.assert_shape("tanh", out.shape, x.shape)
+    # TODO
 
 @given(xps.arrays(dtype=hh.numeric_dtypes, shape=xps.array_shapes()))
 def test_trunc(x):
     out = xp.trunc(x)
-    assert out.dtype == x.dtype, f"{x.dtype=!s} but {out.dtype=!s}"
-    assert out.shape == x.shape, f"{x.shape=} but {out.shape=}"
-    if x.dtype in dh.all_int_dtypes:
-        assert ah.all(ah.equal(x, out)), f"{x=!s} but {out=!s}"
+    ph.assert_shape("bitwise_trunc", out.shape, x.shape)
+    if dh.is_int_dtype(x.dtype):
+        ah.assert_exactly_equal(out, x)
     else:
         finite = ah.isfinite(x)
         ah.assert_integral(out[finite])

--- a/array_api_tests/test_elementwise_functions.py
+++ b/array_api_tests/test_elementwise_functions.py
@@ -12,35 +12,16 @@ special_cases/
 import math
 
 from hypothesis import assume, given
-from hypothesis import strategies as st
 
 from . import _array_module as xp
 from . import array_helpers as ah
-from . import hypothesis_helpers as hh
 from . import dtype_helpers as dh
+from . import hypothesis_helpers as hh
 from . import xps
 # We might as well use this implementation rather than requiring
 # mod.broadcast_shapes(). See test_equal() and others.
 from .test_broadcasting import broadcast_shapes
 
-# integer_scalars = hh.array_scalars(integer_dtypes)
-floating_scalars = hh.array_scalars(hh.floating_dtypes)
-numeric_scalars = hh.array_scalars(hh.numeric_dtypes)
-integer_or_boolean_scalars = hh.array_scalars(hh.integer_or_boolean_dtypes)
-boolean_scalars = hh.array_scalars(hh.boolean_dtypes)
-
-two_integer_dtypes = hh.mutually_promotable_dtypes(dtypes=dh.all_int_dtypes)
-two_floating_dtypes = hh.mutually_promotable_dtypes(dtypes=dh.float_dtypes)
-two_numeric_dtypes = hh.mutually_promotable_dtypes(dtypes=dh.numeric_dtypes)
-two_integer_or_boolean_dtypes = hh.mutually_promotable_dtypes(dtypes=dh.bool_and_all_int_dtypes)
-two_boolean_dtypes = hh.mutually_promotable_dtypes(dtypes=(xp.bool,))
-two_any_dtypes = hh.mutually_promotable_dtypes()
-
-@st.composite
-def two_array_scalars(draw, dtype1, dtype2):
-    # two_dtypes should be a strategy that returns two dtypes (like
-    # hh.mutually_promotable_dtypes())
-    return draw(hh.array_scalars(st.just(dtype1))), draw(hh.array_scalars(st.just(dtype2)))
 
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_abs(x):
@@ -811,44 +792,44 @@ def test_round(x):
     ah.assert_exactly_equal(a[round_down], floor[round_down])
     ah.assert_exactly_equal(a[round_up], ceil[round_up])
 
-@given(numeric_scalars)
+@given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_sign(x):
-    # a = xp.sign(x)
+    # out = xp.sign(x)
     pass
 
-@given(floating_scalars)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_sin(x):
-    # a = xp.sin(x)
+    # out = xp.sin(x)
     pass
 
-@given(floating_scalars)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_sinh(x):
-    # a = xp.sinh(x)
+    # out = xp.sinh(x)
     pass
 
-@given(numeric_scalars)
+@given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_square(x):
-    # a = xp.square(x)
+    # out = xp.square(x)
     pass
 
-@given(floating_scalars)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_sqrt(x):
-    # a = xp.sqrt(x)
+    # out = xp.sqrt(x)
     pass
 
-@given(two_numeric_dtypes.flatmap(lambda i: two_array_scalars(*i)))
-def test_subtract(args):
-    x1, x2 = args
-    # a = xp.subtract(x1, x2)
+@given(*hh.two_mutual_arrays(dh.numeric_dtypes))
+def test_subtract(x1, x2):
+    # out = xp.subtract(x1, x2)
+    pass
 
-@given(floating_scalars)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_tan(x):
-    # a = xp.tan(x)
+    # out = xp.tan(x)
     pass
 
-@given(floating_scalars)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_tanh(x):
-    # a = xp.tanh(x)
+    # out = xp.tanh(x)
     pass
 
 @given(xps.arrays(dtype=hh.numeric_dtypes, shape=xps.array_shapes()))

--- a/array_api_tests/typing.py
+++ b/array_api_tests/typing.py
@@ -2,6 +2,7 @@ from typing import Tuple, Type, Union, Any
 
 __all__ = [
     "DataType",
+    "Scalar",
     "ScalarType",
     "Array",
     "Shape",
@@ -9,6 +10,7 @@ __all__ = [
 ]
 
 DataType = Type[Any]
+Scalar = Union[bool, int, float]
 ScalarType = Union[Type[bool], Type[int], Type[float]]
 Array = Any
 Shape = Tuple[int, ...]

--- a/array_api_tests/typing.py
+++ b/array_api_tests/typing.py
@@ -3,11 +3,13 @@ from typing import Tuple, Type, Union, Any
 __all__ = [
     "DataType",
     "ScalarType",
+    "Array",
     "Shape",
     "Param",
 ]
 
 DataType = Type[Any]
 ScalarType = Union[Type[bool], Type[int], Type[float]]
+Array = Any
 Shape = Tuple[int, ...]
 Param = Tuple


### PR DESCRIPTION
In #30 I'm experimenting with the `ph.assert_dtype()` assertion util. As well as those promoted dtype checks, I realise a lot of dtype assertions relate to the default int and float, so I wanted to experiment with refactoring those too... I didn't get round to that today, seeing as how tricky just understanding `test_arange` was (I think it covers more now at least).