### PR TITLE
Filter undefined dtypes in `hh.mutually_promotable_dtypes()`

### DIFF
--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -1,6 +1,10 @@
 from hypothesis.extra.array_api import make_strategies_namespace
 
-from ._array_module import mod as xp
+from ._array_module import mod as _xp
 
 
-xps = make_strategies_namespace(xp)
+xps = make_strategies_namespace(_xp)
+
+
+del _xp
+del make_strategies_namespace

--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -1,6 +1,6 @@
 from hypothesis.extra.array_api import make_strategies_namespace
 
-from . import _array_module as xp
+from ._array_module import mod as xp
 
 
 xps = make_strategies_namespace(xp)

--- a/array_api_tests/meta/test_hypothesis_helpers.py
+++ b/array_api_tests/meta/test_hypothesis_helpers.py
@@ -15,12 +15,26 @@ UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dh.all_dtypes)
 pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
 
 @given(hh.mutually_promotable_dtypes(dtypes=dh.float_dtypes))
-def test_mutually_promotable_dtypes(pairs):
-    assert pairs in (
+def test_mutually_promotable_dtypes(pair):
+    assert pair in (
         (xp.float32, xp.float32),
         (xp.float32, xp.float64),
         (xp.float64, xp.float32),
         (xp.float64, xp.float64),
+    )
+
+
+@given(
+    hh.mutually_promotable_dtypes(
+        dtypes=[xp.uint8, _UndefinedStub("uint16"), xp.uint32]
+    )
+)
+def test_partial_mutually_promotable_dtypes(pair):
+    assert pair in (
+        (xp.uint8, xp.uint8),
+        (xp.uint8, xp.uint32),
+        (xp.uint32, xp.uint8),
+        (xp.uint32, xp.uint32),
     )
 
 

--- a/array_api_tests/meta/test_partial_adopters.py
+++ b/array_api_tests/meta/test_partial_adopters.py
@@ -1,0 +1,18 @@
+import pytest
+from hypothesis import given
+
+from .. import dtype_helpers as dh
+from .. import hypothesis_helpers as hh
+from .. import _array_module as xp
+from .._array_module import _UndefinedStub
+
+
+# e.g. PyTorch only supports uint8 currently
+@pytest.mark.skipif(isinstance(xp.uint8, _UndefinedStub), reason="uint8 not defined")
+@pytest.mark.skipif(
+    not all(isinstance(d, _UndefinedStub) for d in dh.uint_dtypes[1:]),
+    reason="uints defined",
+)
+@given(hh.mutually_promotable_dtypes(dtypes=dh.uint_dtypes))
+def test_mutually_promotable_dtypes(pair):
+    assert pair == (xp.uint8, xp.uint8)


### PR DESCRIPTION
If `max_size` is not its default value `2`, then `hh.mutually_promotable_dtypes()` before returned undefined dtypes. This PR fixes that. Related to #33.

I now bind `xps` to the underlying array module `mod`, instead of the top-level stubbed one. Hypothesis gives nice errors when it encounters erroneous situations due to partial/incorrect Array API adoption, and like with the dtype strategies in `hypothesis_helpers.py` it will work even if not all dtypes are available.

I also add two test cases, one mocking an array module with undefined dtypes, and one actually testing an array module with undefined dtypes in `test_partial_adopters.py`. Because of how the codebase is structured, it's pretty awkward to test partial adopters like [I had done in Hypothesis](https://github.com/HypothesisWorks/hypothesis/blob/master/hypothesis-python/tests/array_api/test_partial_adoptors.py), but a liberal use of `pytest.mark.skipif()` allows us to test how our own  strategies work with different array modules.