### PR TITLE
Raise `TypeError` on bad `dtypes` in `hh.two_mutual_arrays()`

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -18,7 +18,7 @@ from ._array_module import broadcast_to, eye, float32, float64, full
 from .array_helpers import ndindex
 from .function_stubs import elementwise_functions
 from .pytest_helpers import nargs
-from .typing import DataType, Shape
+from .typing import DataType, Shape, Array
 
 # Set this to True to not fail tests just because a dtype isn't implemented.
 # If no compatible dtype is implemented for a given test, the test will fail
@@ -344,7 +344,9 @@ def multiaxis_indices(draw, shapes):
 def two_mutual_arrays(
     dtypes: Sequence[DataType] = dh.all_dtypes,
     two_shapes: SearchStrategy[Tuple[Shape, Shape]] = two_mutually_broadcastable_shapes,
-) -> SearchStrategy:
+) -> Tuple[SearchStrategy[Array], SearchStrategy[Array]]:
+    if not isinstance(dtypes, Sequence):
+        raise TypeError(f"{dtypes=} not a sequence")
     mutual_dtypes = shared(mutually_promotable_dtypes(dtypes=dtypes))
     mutual_shapes = shared(two_shapes)
     arrays1 = xps.arrays(

--- a/array_api_tests/meta/test_hypothesis_helpers.py
+++ b/array_api_tests/meta/test_hypothesis_helpers.py
@@ -70,6 +70,11 @@ def test_two_mutual_arrays(x1, x2):
     assert broadcast_shapes(x1.shape, x2.shape) in (x1.shape, x2.shape)
 
 
+def test_two_mutual_arrays_raises_on_bad_dtypes():
+    with pytest.raises(TypeError):
+        hh.two_mutual_arrays(dtypes=xps.scalar_dtypes())
+
+
 def test_kwargs():
     results = []
 


### PR DESCRIPTION
Helps mitigate the problem of #33.

Not sure what's up with the failing `test_multiaxis_indexing` test.