### PR TITLE
Monkey patch Hypothesis to work around `st.floats()` bug

### DIFF
--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -1,10 +1,27 @@
-from hypothesis.extra.array_api import make_strategies_namespace
+from hypothesis.extra import array_api
 
+from . import dtype_helpers as dh
 from ._array_module import mod as _xp
 
+__all__ = ["xps"]
 
-xps = make_strategies_namespace(_xp)
+
+# For now we monkey patch the internal _from_dtype() method to work around a bug
+# in st.floats() - see https://github.com/HypothesisWorks/hypothesis/issues/3153
 
 
-del _xp
-del make_strategies_namespace
+broken_from_dtype = array_api._from_dtype
+
+
+def _from_dtype(xp, dtype, **kwargs):
+    strat = broken_from_dtype(_xp, dtype, **kwargs)
+    if dh.is_float_dtype(dtype):
+        smallest_normal = xp.finfo(dtype).smallest_normal
+        strat = strat.filter(lambda n: abs(n) >= smallest_normal)
+    return strat
+
+
+array_api._from_dtype = _from_dtype
+
+
+xps = array_api.make_strategies_namespace(_xp)


### PR DESCRIPTION
Resolves #42 by monkey patching the relevant `hypothesis.extra.array_api` internals to work around HypothesisWorks/hypothesis#3153. This is done by filtering the original `from_dtype()` strategy to throw away the bad floats inbetween the smallest representable non-zero number and zero.