### PR TITLE
Change scope of `test_constants.py`

### DIFF
--- a/array_api_tests/test_constants.py
+++ b/array_api_tests/test_constants.py
@@ -19,7 +19,7 @@ def assert_0d_float(name: str, x: Array):
 
 
 @pytest.mark.parametrize("name, n", [("e", math.e), ("pi", math.pi)])
-def test_irrational(name, n):
+def test_irrational_numbers(name, n):
     assert hasattr(xp, name)
     c = getattr(xp, name)
     assert_scalar_float(name, c)

--- a/array_api_tests/test_constants.py
+++ b/array_api_tests/test_constants.py
@@ -1,34 +1,43 @@
-from ._array_module import (e, inf, nan, pi, equal, isnan, abs, full,
-                            float64, less, isinf, greater, all)
-from .array_helpers import one
+import math
 
-def test_e():
-    # Check that e acts as a scalar
-    E = full((1,), e, dtype=float64)
+import pytest
 
-    # We don't require any accuracy. This is just a smoke test to check that
-    # 'e' is actually the constant e.
-    assert all(less(abs(E - 2.71), one((1,), dtype=float64))), "e is not the constant e"
+from . import dtype_helpers as dh
+from ._array_module import mod as xp
+from .typing import Array
 
-def test_pi():
-    # Check that pi acts as a scalar
-    PI = full((1,), pi, dtype=float64)
 
-    # We don't require any accuracy. This is just a smoke test to check that
-    # 'pi' is actually the constant π.
-    assert all(less(abs(PI - 3.14), one((1,), dtype=float64))), "pi is not the constant π"
+def assert_0d_float(name: str, x: Array):
+    assert dh.is_float_dtype(
+        x.dtype
+    ), f"xp.asarray(xp.{name})={x!r}, but should have float dtype"
+
+
+@pytest.mark.parametrize("name, n", [("e", math.e), ("pi", math.pi)])
+def test_irrational(name, n):
+    assert hasattr(xp, name)
+    c = getattr(xp, name)
+    floor = math.floor(n)
+    assert c > floor, f"xp.{name}={c} <= {floor}"
+    ceil = math.ceil(n)
+    assert c < ceil, f"xp.{name}={c} >= {ceil}"
+    x = xp.asarray(c)
+    assert_0d_float("name", x)
+
 
 def test_inf():
-    # Check that inf acts as a scalar
-    INF = full((1,), inf, dtype=float64)
-    zero = full((1,), 0.0, dtype=float64)
+    assert hasattr(xp, "inf")
+    assert math.isinf(xp.inf)
+    assert xp.inf > 0, "xp.inf not greater than 0"
+    x = xp.asarray(xp.inf)
+    assert_0d_float("inf", x)
+    assert xp.isinf(x), "xp.isinf(xp.asarray(xp.inf))=False"
 
-    assert all(isinf(INF)), "inf is not infinity"
-    assert all(greater(INF, zero)), "inf is not positive"
 
 def test_nan():
-    # Check that nan acts as a scalar
-    NAN = full((1,), nan, dtype=float64)
-
-    assert all(isnan(NAN)), "nan is not Not a Number"
-    assert not all(equal(NAN, NAN)), "nan should be unequal to itself"
+    assert hasattr(xp, "nan")
+    assert math.isnan(xp.nan)
+    assert xp.nan != xp.nan, "xp.nan should not have equality with itself"
+    x = xp.asarray(xp.nan)
+    assert_0d_float("nan", x)
+    assert xp.isnan(x), "xp.isnan(xp.asarray(xp.nan))=False"

--- a/array_api_tests/test_constants.py
+++ b/array_api_tests/test_constants.py
@@ -1,10 +1,15 @@
 import math
+from typing import Any, SupportsFloat
 
 import pytest
 
 from . import dtype_helpers as dh
 from ._array_module import mod as xp
 from .typing import Array
+
+
+def assert_scalar_float(name: str, c: Any):
+    assert isinstance(c, SupportsFloat), f"{name}={c!r} does not look like a float"
 
 
 def assert_0d_float(name: str, x: Array):
@@ -17,16 +22,18 @@ def assert_0d_float(name: str, x: Array):
 def test_irrational(name, n):
     assert hasattr(xp, name)
     c = getattr(xp, name)
+    assert_scalar_float(name, c)
     floor = math.floor(n)
-    assert c > floor, f"xp.{name}={c} <= {floor}"
+    assert c > floor, f"xp.{name}={c!r} <= {floor}"
     ceil = math.ceil(n)
-    assert c < ceil, f"xp.{name}={c} >= {ceil}"
+    assert c < ceil, f"xp.{name}={c!r} >= {ceil}"
     x = xp.asarray(c)
     assert_0d_float("name", x)
 
 
 def test_inf():
     assert hasattr(xp, "inf")
+    assert_scalar_float("inf", xp.inf)
     assert math.isinf(xp.inf)
     assert xp.inf > 0, "xp.inf not greater than 0"
     x = xp.asarray(xp.inf)
@@ -36,6 +43,7 @@ def test_inf():
 
 def test_nan():
     assert hasattr(xp, "nan")
+    assert_scalar_float("nan", xp.nan)
     assert math.isnan(xp.nan)
     assert xp.nan != xp.nan, "xp.nan should not have equality with itself"
     x = xp.asarray(xp.nan)


### PR DESCRIPTION
This PR:
- Removes dependencies on most `xp` functions, as they're not interesting IMO so unnecessarily increase dependencies
  - Note these tests were written before data-apis/array-api#169 where such use of arrays was necessary
  - Opted to use pure Python equalities instead
- Instance checks the constants should work like floats i.e. supports `__float__` 
  - `float` check would hurt duck typed implementations, see https://github.com/data-apis/array-api/issues/154#issuecomment-833746576
  - [`numerary`](https://posita.github.io/numerary/0.1/) stuff doesn't look necessary here (interesting for other parts of the suite tho)
- Adds interesting equality checks that @pmeier wrote for #15... useful if we're not assuming `float`

Clarifying we don't need constants to be specifically `float` should close #14 and #15.