### PR TITLE
Better undefined dtype behaviour

### DIFF
--- a/xptests/hypothesis_helpers.py
+++ b/xptests/hypothesis_helpers.py
@@ -67,7 +67,13 @@ def _dtypes_sorter(dtype_pair: Tuple[DataType, DataType]):
         key += 1
     return key
 
-promotable_dtypes: List[Tuple[DataType, DataType]] = sorted(dh.promotion_table.keys(), key=_dtypes_sorter)
+_promotable_dtypes = list(dh.promotion_table.keys())
+if FILTER_UNDEFINED_DTYPES:
+    _promotable_dtypes = [
+        (d1, d2) for d1, d2 in _promotable_dtypes
+        if not isinstance(d1, _UndefinedStub) or not isinstance(d2, _UndefinedStub)
+    ]
+promotable_dtypes: List[Tuple[DataType, DataType]] = sorted(_promotable_dtypes, key=_dtypes_sorter)
 
 def mutually_promotable_dtypes(
     max_size: Optional[int] = 2,

--- a/xptests/test_array2scalar.py
+++ b/xptests/test_array2scalar.py
@@ -17,8 +17,16 @@ method_stype = {
 
 def make_param(method_name: str, dtype: DataType) -> Param:
     stype = method_stype[method_name]
+    if isinstance(dtype, xp._UndefinedStub):
+        marks = pytest.mark.skip(reason=f"xp.{dtype.name} not defined")
+    else:
+        marks = ()
     return pytest.param(
-        method_name, dtype, stype, id=f"{method_name}({dh.dtype_to_name[dtype]})"
+        method_name,
+        dtype,
+        stype,
+        id=f"{method_name}({dh.dtype_to_name[dtype]})",
+        marks=marks,
     )
 
 

--- a/xptests/test_elementwise_functions.py
+++ b/xptests/test_elementwise_functions.py
@@ -53,6 +53,8 @@ UnaryParam = Param[str, Callable[[Array], Array], st.SearchStrategy[Array]]
 def make_unary_params(
     elwise_func_name: str, dtypes: Sequence[DataType]
 ) -> List[UnaryParam]:
+    if hh.FILTER_UNDEFINED_DTYPES:
+        dtypes = [d for d in dtypes if not isinstance(d, xp._UndefinedStub)]
     strat = xps.arrays(dtype=st.sampled_from(dtypes), shape=hh.shapes())
     func = getattr(xp, elwise_func_name)
     op_name = func_to_op[elwise_func_name]
@@ -93,6 +95,8 @@ class FuncType(Enum):
 def make_binary_params(
     elwise_func_name: str, dtypes: Sequence[DataType]
 ) -> List[BinaryParam]:
+    if hh.FILTER_UNDEFINED_DTYPES:
+        dtypes = [d for d in dtypes if not isinstance(d, xp._UndefinedStub)]
     dtypes_strat = st.sampled_from(dtypes)
 
     def make_param(


### PR DESCRIPTION
This PR fixes some issues with undefined dtypes not being filtered from custom Hypothesis strategies, and additionally skips test cases which are explicitly passed undefined dtypes (i.e. for type promotion). cc @pmeier 