### PR TITLE
`test_concat` fixes

### DIFF
--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -63,9 +63,9 @@ def test_concat(dtypes, kw, data):
     if axis is None:
         shape_strat = hh.shapes()
     else:
-        _axis = axis if axis >= 0 else abs(axis) - 1
-        shape_strat = shared_shapes(min_dims=_axis + 1).flatmap(
-            lambda s: concat_shapes(s, axis)
+        any_side_axis = axis if axis >= 0 else abs(axis) - 1
+        shape_strat = shared_shapes(min_dims=any_side_axis + 1).flatmap(
+            lambda s: concat_shapes(s, any_side_axis)
         )
     arrays = []
     for i, dtype in enumerate(dtypes, 1):
@@ -102,6 +102,8 @@ def test_concat(dtypes, kw, data):
                     **kw,
                 )
     else:
+        ndim = len(shapes[0])
+        _axis = axis if axis >= 0 else ndim - 1
         out_indices = sh.ndindex(out.shape)
         for idx in sh.axis_ndindex(shapes[0], _axis):
             f_idx = ", ".join(str(i) if isinstance(i, int) else ":" for i in idx)


### PR DESCRIPTION
I had inferred the incorrect normalised axis for my test logic, which was causing problems for NumPy (had to use higher max examples, which is why I didn't seem to catch this problem the first time heh). This PR fixes that and clears up the argument drawing a bit.

Could help with #70?

- [x] Make this more performative by generating the base shape first