### PR TITLE
Add a better mutually_broadcastable_shapes strategy

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -174,10 +174,10 @@ def mutually_broadcastable_shapes(draw, num_shapes, **kwargs):
     # too much. So instead, we trick it into generating more interesting
     # examples by telling it to create shapes that broadcast against some base
     # shape.
-    if 'base_shape' not in kwargs:
-        base_shape = draw(shapes())
-        kwargs.setdefault('base_shape', base_shape)
     kwargs.setdefault('min_side', 0)
+    if 'base_shape' not in kwargs:
+        base_shape = draw(shapes(**kwargs))
+        kwargs['base_shape'] = base_shape
 
     input_shapes, result_shape = draw(xps.mutually_broadcastable_shapes(num_shapes, **kwargs))
 
@@ -190,9 +190,7 @@ def mutually_broadcastable_shapes(draw, num_shapes, **kwargs):
     # The broadcast compatible shapes can be bigger than the base shape. This
     # is already somewhat limited by the mutually_broadcastable_shapes
     # defaults, and pretty unlikely, but we filter again here just to be safe.
-    if not prod([i for i in final_result_shape if i]) < SQRT_MAX_ARRAY_SIZE:
-        note(f"Filtering in mutually_broadcastable_shapes {result_shape}")
-        assume(False)
+    assume(prod(i for i in final_result_shape if i) < SQRT_MAX_ARRAY_SIZE)
 
     # The hypothesis strategy would return this. We don't actually need the
     # result shape in most cases (if we end up needing it, we can uncomment


### PR DESCRIPTION
This is based on the work from
https://github.com/Quansight-Labs/ndindex/pull/126. The strategy that comes
with hypothesis has default parameters that makes it not generate interesting
examples by default. In particular, it will never generate a shape with more
than 2 dimensions and side length more than 3.

This new strategy generates shapes that are based on a base shape drawn from
shapes(), so more complex shapes are possible. This is preferable to doing so
by modifying the parameters to mutually_broadcastable_shapes() because it's
difficult to find parameters that give interesting examples but don't require
too much filtering for total size.

This commit also changes it so that mutually_broadcastable_shapes generates
shapes with minimum side length 0 by default.

For example, before this commit:

```py
>>> from array_api_tests.hypothesis_helpers import mutually_broadcastable_shapes
>>> for i in range(10):
...     print(mutually_broadcastable_shapes(2).example())
((3,), (3, 1))
((), (3,))
((), (2,))
((1,), ())
((3,), ())
((), (1,))
((1,), (1, 1))
((2,), ())
((), (1,))
((3,), ())
```

After this commit:

```py
>>> for i in range(10):
...     print(mutually_broadcastable_shapes(2).example())
((), (1, 1))
((0, 1), (1, 1, 1, 1))
((1, 3, 1, 1), (3, 1, 4))
((), ())
((1, 5, 1), (1, 5, 1))
((1, 1), (2, 2))
((1,), (2, 0, 1))
((), (1, 1, 1, 2))
((), ())
((), (1, 4, 1))
```

The generation with this new strategy is somewhat slower than the old one
(about 2x slower), but the generation speed is not slow enough that it should
matter too much.

The shrinking can also be imperfect with this strategy. For example, I've seen
it shrink to ((0, 1), (0, 2)) for the currently failing in-place tests where
it could shrink to just ((1,), (2,)). I also saw the pre-existing strategy
have the same problem, however. One should just be aware that test failures
involving shapes from this strategy might not actually be shrunk minimally.