### PR TITLE
Use ndindex.iter_indices in _test_stacks in the linalg tests

### DIFF
--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -34,8 +34,9 @@ jobs:
         array_api_tests/test_creation_functions.py::test_linspace
         # https://github.com/numpy/numpy/issues/20870
         array_api_tests/test_data_type_functions.py::test_can_cast
-        # linalg tests generally need more mulling over
-        array_api_tests/test_linalg.py
+        # The return dtype for trace is not consistent in the spec
+        # (https://github.com/data-apis/array-api/issues/202#issuecomment-952529197)
+        array_api_tests/test_linalg.py::test_trace
         # waiting on NumPy to allow/revert distinct NaNs for np.unique
         # https://github.com/numpy/numpy/issues/20326#issuecomment-1012380448
         array_api_tests/test_set_functions.py

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -71,19 +71,6 @@ def _test_stacks(f, *args, res=None, dims=2, true_val=None, matrix_axes=(-2, -1)
             iter_indices(res.shape, skip_axes=tuple(range(-dims, 0)))):
         x_idxes = [x_idx.raw for x_idx in x_idxes]
         res_idx = res_idx.raw
-        # res should have `dims` slices in it. Cases where there are more than
-        # `dims` slices are ambiguous, but that should only occur in cases
-        # where axes = (-2, -1).
-        # res_idx2 = []
-        # d = dims
-        # for i in res_idx:
-        #     if isinstance(i, slice):
-        #         if d:
-        #             res_idx2.append(i)
-        #             d -= 1
-        #     else:
-        #         res_idx2.append(i)
-        # res_idx2 = tuple(res_idx2)
 
         res_stack = res[res_idx]
         x_stacks = [x[x_idx] for x, x_idx in zip(args, x_idxes)]

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -16,10 +16,10 @@ required, but we don't yet have a clean way to disable only those tests (see htt
 import pytest
 from hypothesis import assume, given
 from hypothesis.strategies import (booleans, composite, none, tuples, integers,
-                                   shared, sampled_from, one_of, data, just)
+                                   shared, sampled_from, data, just)
 from ndindex import iter_indices
 
-from .array_helpers import assert_exactly_equal, asarray, equal, zero, infinity
+from .array_helpers import assert_exactly_equal, asarray
 from .hypothesis_helpers import (xps, dtypes, shapes, kwargs, matrix_shapes,
                                  square_matrix_shapes, symmetric_matrices,
                                  positive_definite_matrices, MAX_ARRAY_SIZE,

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -628,7 +628,7 @@ def test_trace(x, kw):
 
 @given(
     dtypes=mutually_promotable_dtypes(dtypes=dh.numeric_dtypes),
-    shape=shapes(),
+    shape=shapes(min_dims=1),
     data=data(),
 )
 def test_vecdot(dtypes, shape, data):

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -464,10 +464,12 @@ def test_slogdet(x):
 
     # Check that when the determinant is 0, the sign and logabsdet are (0,
     # -inf).
-    d = linalg.det(x)
-    zero_det = equal(d, zero(d.shape, d.dtype))
-    assert_exactly_equal(sign[zero_det], zero(sign[zero_det].shape, x.dtype))
-    assert_exactly_equal(logabsdet[zero_det], -infinity(logabsdet[zero_det].shape, x.dtype))
+    # TODO: This test does not necessarily hold exactly. Update it to test it
+    # approximately.
+    # d = linalg.det(x)
+    # zero_det = equal(d, zero(d.shape, d.dtype))
+    # assert_exactly_equal(sign[zero_det], zero(sign[zero_det].shape, x.dtype))
+    # assert_exactly_equal(logabsdet[zero_det], -infinity(logabsdet[zero_det].shape, x.dtype))
 
     # More generally, det(x) should equal sign*exp(logabsdet), but this does
     # not hold exactly due to floating-point loss of precision.

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -44,7 +44,8 @@ pytestmark = pytest.mark.ci
 # Standin strategy for not yet implemented tests
 todo = none()
 
-def _test_stacks(f, *args, res=None, dims=2, true_val=None, matrix_axes=(-2, -1), **kw):
+def _test_stacks(f, *args, res=None, dims=2, true_val=None, matrix_axes=(-2, -1),
+                 assert_equal=assert_exactly_equal, **kw):
     """
     Test that f(*args, **kw) maps across stacks of matrices
 
@@ -75,9 +76,9 @@ def _test_stacks(f, *args, res=None, dims=2, true_val=None, matrix_axes=(-2, -1)
         res_stack = res[res_idx]
         x_stacks = [x[x_idx] for x, x_idx in zip(args, x_idxes)]
         decomp_res_stack = f(*x_stacks, **kw)
-        assert_exactly_equal(res_stack, decomp_res_stack)
+        assert_equal(res_stack, decomp_res_stack)
         if true_val:
-            assert_exactly_equal(decomp_res_stack, true_val(*x_stacks))
+            assert_equal(decomp_res_stack, true_val(*x_stacks))
 
 def _test_namedtuple(res, fields, func_name):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
 hypothesis>=6.31.1
+ndindex>=1.6
 regex
 removestar


### PR DESCRIPTION
This adds ndindex >= 1.6 as a dependency of the test suite.

I'm also going to try to make the tests pass. 

I want to update some of the existing tests to use this as well, but I am going to do that in a second PR because it shouldn't block a release. 