### PR TITLE
Increase coverage and other niceties for the operator/elementwise tests

### DIFF
--- a/array_api_tests/array_helpers.py
+++ b/array_api_tests/array_helpers.py
@@ -306,14 +306,3 @@ def same_sign(x, y):
 def assert_same_sign(x, y):
     assert all(same_sign(x, y)), "The input arrays do not have the same sign"
 
-def int_to_dtype(x, n, signed):
-    """
-    Convert the Python integer x into an n bit signed or unsigned number.
-    """
-    mask = (1 << n) - 1
-    x &= mask
-    if signed:
-        highest_bit = 1 << (n-1)
-        if x & highest_bit:
-            x = -((~x & mask) + 1)
-    return x

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -16,7 +16,6 @@ from . import xps
 from ._array_module import _UndefinedStub
 from ._array_module import bool as bool_dtype
 from ._array_module import broadcast_to, eye, float32, float64, full
-from .algos import broadcast_shapes
 from .function_stubs import elementwise_functions
 from .pytest_helpers import nargs
 from .typing import Array, DataType, Shape
@@ -243,7 +242,7 @@ def two_broadcastable_shapes(draw):
     broadcast to shape1.
     """
     shape1, shape2 = draw(two_mutually_broadcastable_shapes)
-    assume(broadcast_shapes(shape1, shape2) == shape1)
+    assume(sh.broadcast_shapes(shape1, shape2) == shape1)
     return (shape1, shape2)
 
 sizes = integers(0, MAX_ARRAY_SIZE)

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -369,6 +369,9 @@ def two_mutual_arrays(
 ) -> Tuple[SearchStrategy[Array], SearchStrategy[Array]]:
     if not isinstance(dtypes, Sequence):
         raise TypeError(f"{dtypes=} not a sequence")
+    if FILTER_UNDEFINED_DTYPES:
+        dtypes = [d for d in dtypes if not isinstance(d, _UndefinedStub)]
+        assert len(dtypes) > 0  # sanity check
     mutual_dtypes = shared(mutually_promotable_dtypes(dtypes=dtypes))
     mutual_shapes = shared(two_shapes)
     arrays1 = xps.arrays(

--- a/array_api_tests/meta/test_array_helpers.py
+++ b/array_api_tests/meta/test_array_helpers.py
@@ -1,10 +1,5 @@
-from hypothesis import given, assume
-from hypothesis.strategies import integers
-
-from ..array_helpers import exactly_equal, notequal, int_to_dtype
-from ..hypothesis_helpers import integer_dtypes
-from ..dtype_helpers import dtype_nbits, dtype_signed
 from .. import _array_module as xp
+from ..array_helpers import exactly_equal, notequal
 
 # TODO: These meta-tests currently only work with NumPy
 
@@ -22,12 +17,3 @@ def test_notequal():
     res = xp.asarray([False, True, False, False, False, True, False, True])
     assert xp.all(xp.equal(notequal(a, b), res))
 
-@given(integers(), integer_dtypes)
-def test_int_to_dtype(x, dtype):
-    n = dtype_nbits[dtype]
-    signed = dtype_signed[dtype]
-    try:
-        d = xp.asarray(x, dtype=dtype)
-    except OverflowError:
-        assume(False)
-    assert int_to_dtype(x, n, signed) == d

--- a/array_api_tests/meta/test_broadcasting.py
+++ b/array_api_tests/meta/test_broadcasting.py
@@ -4,7 +4,7 @@ https://github.com/data-apis/array-api/blob/master/spec/API_specification/broadc
 
 import pytest
 
-from ..algos import BroadcastError, _broadcast_shapes
+from .. import shape_helpers as sh
 
 
 @pytest.mark.parametrize(
@@ -19,7 +19,7 @@ from ..algos import BroadcastError, _broadcast_shapes
     ],
 )
 def test_broadcast_shapes(shape1, shape2, expected):
-    assert _broadcast_shapes(shape1, shape2) == expected
+    assert sh._broadcast_shapes(shape1, shape2) == expected
 
 
 @pytest.mark.parametrize(
@@ -31,5 +31,5 @@ def test_broadcast_shapes(shape1, shape2, expected):
     ],
 )
 def test_broadcast_shapes_fails_on_bad_shapes(shape1, shape2):
-    with pytest.raises(BroadcastError):
-        _broadcast_shapes(shape1, shape2)
+    with pytest.raises(sh.BroadcastError):
+        sh._broadcast_shapes(shape1, shape2)

--- a/array_api_tests/meta/test_hypothesis_helpers.py
+++ b/array_api_tests/meta/test_hypothesis_helpers.py
@@ -8,9 +8,9 @@ from .. import _array_module as xp
 from .. import array_helpers as ah
 from .. import dtype_helpers as dh
 from .. import hypothesis_helpers as hh
+from .. import shape_helpers as sh
 from .. import xps
 from .._array_module import _UndefinedStub
-from ..algos import broadcast_shapes
 
 UNDEFINED_DTYPES = any(isinstance(d, _UndefinedStub) for d in dh.all_dtypes)
 pytestmark = [pytest.mark.skipif(UNDEFINED_DTYPES, reason="undefined dtypes")]
@@ -62,7 +62,7 @@ def test_two_mutually_broadcastable_shapes(pair):
 def test_two_broadcastable_shapes(pair):
     for shape in pair:
         assert valid_shape(shape)
-    assert broadcast_shapes(pair[0], pair[1]) == pair[0]
+    assert sh.broadcast_shapes(pair[0], pair[1]) == pair[0]
 
 
 @given(*hh.two_mutual_arrays())

--- a/array_api_tests/meta/test_pytest_helpers.py
+++ b/array_api_tests/meta/test_pytest_helpers.py
@@ -5,9 +5,9 @@ from .. import _array_module as xp
 
 
 def test_assert_dtype():
-    ph.assert_dtype("promoted_func", (xp.uint8, xp.int8), xp.int16)
+    ph.assert_dtype("promoted_func", [xp.uint8, xp.int8], xp.int16)
     with raises(AssertionError):
-        ph.assert_dtype("bad_func", (xp.uint8, xp.int8), xp.float32)
-    ph.assert_dtype("bool_func", (xp.uint8, xp.int8), xp.bool, xp.bool)
-    ph.assert_dtype("single_promoted_func", (xp.uint8,), xp.uint8)
-    ph.assert_dtype("single_bool_func", (xp.uint8,), xp.bool, xp.bool)
+        ph.assert_dtype("bad_func", [xp.uint8, xp.int8], xp.float32)
+    ph.assert_dtype("bool_func", [xp.uint8, xp.int8], xp.bool, xp.bool)
+    ph.assert_dtype("single_promoted_func", [xp.uint8], xp.uint8)
+    ph.assert_dtype("single_bool_func", [xp.uint8], xp.bool, xp.bool)

--- a/array_api_tests/meta/test_utils.py
+++ b/array_api_tests/meta/test_utils.py
@@ -1,8 +1,13 @@
 import pytest
+from hypothesis import given, reject
+from hypothesis import strategies as st
 
+from .. import _array_module as xp
+from .. import xps
 from .. import shape_helpers as sh
 from ..test_creation_functions import frange
 from ..test_manipulation_functions import roll_ndindex
+from ..test_operators_and_elementwise_functions import mock_int_dtype
 from ..test_signatures import extension_module
 
 
@@ -101,3 +106,12 @@ def test_roll_ndindex(shape, shifts, axes, expected):
 )
 def test_fmt_idx(idx, expected):
     assert sh.fmt_idx("x", idx) == expected
+
+
+@given(x=st.integers(), dtype=xps.unsigned_integer_dtypes() | xps.integer_dtypes())
+def test_int_to_dtype(x, dtype):
+    try:
+        d = xp.asarray(x, dtype=dtype)
+    except OverflowError:
+        reject()
+    assert mock_int_dtype(x, dtype) == d

--- a/array_api_tests/meta/test_utils.py
+++ b/array_api_tests/meta/test_utils.py
@@ -82,3 +82,22 @@ def test_axes_ndindex(shape, axes, expected):
 )
 def test_roll_ndindex(shape, shifts, axes, expected):
     assert list(roll_ndindex(shape, shifts, axes)) == expected
+
+
+@pytest.mark.parametrize(
+    "idx, expected",
+    [
+        ((), "x"),
+        (42, "x[42]"),
+        ((42,), "x[42]"),
+        (slice(None, 2), "x[:2]"),
+        (slice(2, None), "x[2:]"),
+        (slice(0, 2), "x[0:2]"),
+        (slice(0, 2, -1), "x[0:2:-1]"),
+        (slice(None, None, -1), "x[::-1]"),
+        (slice(None, None), "x[:]"),
+        (..., "x[...]"),
+    ],
+)
+def test_fmt_idx(idx, expected):
+    assert sh.fmt_idx("x", idx) == expected

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -149,7 +149,7 @@ def assert_shape(
 
 def assert_result_shape(
     func_name: str,
-    in_shapes: Tuple[Shape],
+    in_shapes: Sequence[Shape],
     out_shape: Shape,
     /,
     expected: Optional[Shape] = None,

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -1,6 +1,6 @@
 import math
 from inspect import getfullargspec
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 from . import _array_module as xp
 from . import array_helpers as ah
@@ -71,15 +71,14 @@ def fmt_kw(kw: Dict[str, Any]) -> str:
 
 def assert_dtype(
     func_name: str,
-    in_dtypes: Union[DataType, Tuple[DataType, ...]],
+    in_dtype: Union[DataType, Sequence[DataType]],
     out_dtype: DataType,
     expected: Optional[DataType] = None,
     *,
     repr_name: str = "out.dtype",
 ):
-    if not isinstance(in_dtypes, tuple):
-        in_dtypes = (in_dtypes,)
-    f_in_dtypes = dh.fmt_types(in_dtypes)
+    in_dtypes = in_dtype if isinstance(in_dtype, Sequence) else [in_dtype]
+    f_in_dtypes = dh.fmt_types(tuple(in_dtypes))
     f_out_dtype = dh.dtype_to_name[out_dtype]
     if expected is None:
         expected = dh.result_type(*in_dtypes)

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -6,7 +6,7 @@ from . import _array_module as xp
 from . import array_helpers as ah
 from . import dtype_helpers as dh
 from . import function_stubs
-from .algos import broadcast_shapes
+from . import shape_helpers as sh
 from .typing import Array, DataType, Scalar, ScalarType, Shape
 
 __all__ = [
@@ -159,7 +159,7 @@ def assert_result_shape(
     **kw,
 ):
     if expected is None:
-        expected = broadcast_shapes(*in_shapes)
+        expected = sh.broadcast_shapes(*in_shapes)
     f_in_shapes = " . ".join(str(s) for s in in_shapes)
     f_sig = f" {f_in_shapes} "
     if kw:

--- a/array_api_tests/shape_helpers.py
+++ b/array_api_tests/shape_helpers.py
@@ -4,9 +4,16 @@ from typing import Iterator, List, Optional, Tuple, Union
 
 from ndindex import iter_indices as _iter_indices
 
-from .typing import Scalar, Shape
+from .typing import AtomicIndex, Index, Scalar, Shape
 
-__all__ = ["normalise_axis", "ndindex", "axis_ndindex", "axes_ndindex", "reshape"]
+__all__ = [
+    "normalise_axis",
+    "ndindex",
+    "axis_ndindex",
+    "axes_ndindex",
+    "reshape",
+    "fmt_idx",
+]
 
 
 def normalise_axis(
@@ -64,7 +71,7 @@ def axes_ndindex(shape: Shape, axes: Tuple[int, ...]) -> Iterator[List[Shape]]:
         yield list(indices)
 
 
-def reshape(flat_seq: List[Scalar], shape: Shape) -> Union[Scalar, List[Scalar]]:
+def reshape(flat_seq: List[Scalar], shape: Shape) -> Union[Scalar, List]:
     """Reshape a flat sequence"""
     if any(s == 0 for s in shape):
         raise ValueError(
@@ -79,3 +86,33 @@ def reshape(flat_seq: List[Scalar], shape: Shape) -> Union[Scalar, List[Scalar]]
     size = len(flat_seq)
     n = math.prod(shape[1:])
     return [reshape(flat_seq[i * n : (i + 1) * n], shape[1:]) for i in range(size // n)]
+
+
+def fmt_i(i: AtomicIndex) -> str:
+    if isinstance(i, int):
+        return str(i)
+    elif isinstance(i, slice):
+        res = ""
+        if i.start is not None:
+            res += str(i.start)
+        res += ":"
+        if i.stop is not None:
+            res += str(i.stop)
+        if i.step is not None:
+            res += f":{i.step}"
+        return res
+    else:
+        return "..."
+
+
+def fmt_idx(sym: str, idx: Index) -> str:
+    if idx == ():
+        return sym
+    res = f"{sym}["
+    _idx = idx if isinstance(idx, tuple) else (idx,)
+    if len(_idx) == 1:
+        res += fmt_i(_idx[0])
+    else:
+        res += ", ".join(fmt_i(i) for i in _idx)
+    res += "]"
+    return res

--- a/array_api_tests/shape_helpers.py
+++ b/array_api_tests/shape_helpers.py
@@ -1,5 +1,4 @@
 import math
-from functools import lru_cache
 from itertools import product
 from typing import Iterator, List, Optional, Tuple, Union
 
@@ -161,7 +160,6 @@ def fmt_i(i: AtomicIndex) -> str:
         return "..."
 
 
-@lru_cache
 def fmt_idx(sym: str, idx: Index) -> str:
     if idx == ():
         return sym

--- a/array_api_tests/shape_helpers.py
+++ b/array_api_tests/shape_helpers.py
@@ -76,15 +76,21 @@ def normalise_axis(
     return axes
 
 
-def ndindex(shape):
-    """Yield every index of shape"""
+def ndindex(shape: Shape) -> Iterator[Index]:
+    """Yield every index of a shape"""
     return (indices[0] for indices in iter_indices(shape))
 
 
-def iter_indices(*shapes, skip_axes=()):
+def iter_indices(
+    *shapes: Shape, skip_axes: Tuple[int, ...] = ()
+) -> Iterator[Tuple[Index, ...]]:
     """Wrapper for ndindex.iter_indices()"""
-    gen = _iter_indices(*shapes, skip_axes=skip_axes)
-    return ([i.raw for i in indices] for indices in gen)
+    # Prevent iterations if any shape has 0-sides
+    for shape in shapes:
+        if 0 in shape:
+            return
+    for indices in _iter_indices(*shapes, skip_axes=skip_axes):
+        yield tuple(i.raw for i in indices)  # type: ignore
 
 
 def axis_ndindex(

--- a/array_api_tests/shape_helpers.py
+++ b/array_api_tests/shape_helpers.py
@@ -1,4 +1,5 @@
 import math
+from functools import lru_cache
 from itertools import product
 from typing import Iterator, List, Optional, Tuple, Union
 
@@ -27,7 +28,7 @@ def normalise_axis(
 
 
 def ndindex(shape):
-    # TODO: remove
+    """Yield every index of shape"""
     return (indices[0] for indices in iter_indices(shape))
 
 
@@ -105,6 +106,7 @@ def fmt_i(i: AtomicIndex) -> str:
         return "..."
 
 
+@lru_cache
 def fmt_idx(sym: str, idx: Index) -> str:
     if idx == ():
         return sym

--- a/array_api_tests/shape_helpers.py
+++ b/array_api_tests/shape_helpers.py
@@ -2,6 +2,8 @@ import math
 from itertools import product
 from typing import Iterator, List, Optional, Tuple, Union
 
+from ndindex import iter_indices as _iter_indices
+
 from .typing import Scalar, Shape
 
 __all__ = ["normalise_axis", "ndindex", "axis_ndindex", "axes_ndindex", "reshape"]
@@ -18,12 +20,14 @@ def normalise_axis(
 
 
 def ndindex(shape):
-    """Iterator of n-D indices to an array
+    # TODO: remove
+    return (indices[0] for indices in iter_indices(shape))
 
-    Yields tuples of integers to index every element of an array of shape
-    `shape`. Same as np.ndindex().
-    """
-    return product(*[range(i) for i in shape])
+
+def iter_indices(*shapes, skip_axes=()):
+    """Wrapper for ndindex.iter_indices()"""
+    gen = _iter_indices(*shapes, skip_axes=skip_axes)
+    return ([i.raw for i in indices] for indices in gen)
 
 
 def axis_ndindex(

--- a/array_api_tests/shape_helpers.py
+++ b/array_api_tests/shape_helpers.py
@@ -8,6 +8,7 @@ from ndindex import iter_indices as _iter_indices
 from .typing import AtomicIndex, Index, Scalar, Shape
 
 __all__ = [
+    "broadcast_shapes",
     "normalise_axis",
     "ndindex",
     "axis_ndindex",
@@ -15,6 +16,54 @@ __all__ = [
     "reshape",
     "fmt_idx",
 ]
+
+
+class BroadcastError(ValueError):
+    """Shapes do not broadcast with eachother"""
+
+
+def _broadcast_shapes(shape1: Shape, shape2: Shape) -> Shape:
+    """Broadcasts `shape1` and `shape2`"""
+    N1 = len(shape1)
+    N2 = len(shape2)
+    N = max(N1, N2)
+    shape = [None for _ in range(N)]
+    i = N - 1
+    while i >= 0:
+        n1 = N1 - N + i
+        if N1 - N + i >= 0:
+            d1 = shape1[n1]
+        else:
+            d1 = 1
+        n2 = N2 - N + i
+        if N2 - N + i >= 0:
+            d2 = shape2[n2]
+        else:
+            d2 = 1
+
+        if d1 == 1:
+            shape[i] = d2
+        elif d2 == 1:
+            shape[i] = d1
+        elif d1 == d2:
+            shape[i] = d1
+        else:
+            raise BroadcastError()
+
+        i = i - 1
+
+    return tuple(shape)
+
+
+def broadcast_shapes(*shapes: Shape):
+    if len(shapes) == 0:
+        raise ValueError("shapes=[] must be non-empty")
+    elif len(shapes) == 1:
+        return shapes[0]
+    result = _broadcast_shapes(shapes[0], shapes[1])
+    for i in range(2, len(shapes)):
+        result = _broadcast_shapes(result, shapes[i])
+    return result
 
 
 def normalise_axis(

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -152,7 +152,7 @@ def test_arange(dtype, data):
         else:
             ph.assert_default_float("arange", out.dtype)
     else:
-        ph.assert_dtype("arange", (out.dtype,), dtype)
+        ph.assert_kw_dtype("arange", dtype, out.dtype)
     f_sig = ", ".join(str(n) for n in args)
     if len(kwargs) > 0:
         f_sig += f", {ph.fmt_kw(kwargs)}"
@@ -302,7 +302,7 @@ def test_empty(shape, kw):
 def test_empty_like(x, kw):
     out = xp.empty_like(x, **kw)
     if kw.get("dtype", None) is None:
-        ph.assert_dtype("empty_like", (x.dtype,), out.dtype)
+        ph.assert_dtype("empty_like", x.dtype, out.dtype)
     else:
         ph.assert_kw_dtype("empty_like", kw["dtype"], out.dtype)
     ph.assert_shape("empty_like", out.shape, x.shape)
@@ -399,7 +399,7 @@ def test_full_like(x, fill_value, kw):
     out = xp.full_like(x, fill_value, **kw)
     dtype = kw.get("dtype", None) or x.dtype
     if kw.get("dtype", None) is None:
-        ph.assert_dtype("full_like", (x.dtype,), out.dtype)
+        ph.assert_dtype("full_like", x.dtype, out.dtype)
     else:
         ph.assert_kw_dtype("full_like", kw["dtype"], out.dtype)
     ph.assert_shape("full_like", out.shape, x.shape)
@@ -459,7 +459,7 @@ def test_linspace(num, dtype, endpoint, data):
     if dtype is None:
         ph.assert_default_float("linspace", out.dtype)
     else:
-        ph.assert_dtype("linspace", (out.dtype,), dtype)
+        ph.assert_kw_dtype("linspace", dtype, out.dtype)
     ph.assert_shape("linspace", out.shape, num, start=stop, stop=stop, num=num)
     f_func = f"[linspace({start}, {stop}, {num})]"
     if num > 0:
@@ -529,7 +529,7 @@ def test_ones(shape, kw):
 def test_ones_like(x, kw):
     out = xp.ones_like(x, **kw)
     if kw.get("dtype", None) is None:
-        ph.assert_dtype("ones_like", (x.dtype,), out.dtype)
+        ph.assert_dtype("ones_like", x.dtype, out.dtype)
     else:
         ph.assert_kw_dtype("ones_like", kw["dtype"], out.dtype)
     ph.assert_shape("ones_like", out.shape, x.shape)
@@ -565,7 +565,7 @@ def test_zeros(shape, kw):
 def test_zeros_like(x, kw):
     out = xp.zeros_like(x, **kw)
     if kw.get("dtype", None) is None:
-        ph.assert_dtype("zeros_like", (x.dtype,), out.dtype)
+        ph.assert_dtype("zeros_like", x.dtype, out.dtype)
     else:
         ph.assert_kw_dtype("zeros_like", kw["dtype"], out.dtype)
     ph.assert_shape("zeros_like", out.shape, x.shape)

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -9,8 +9,8 @@ from . import _array_module as xp
 from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
+from . import shape_helpers as sh
 from . import xps
-from .algos import broadcast_shapes
 from .typing import DataType
 
 pytestmark = pytest.mark.ci
@@ -70,7 +70,7 @@ def test_broadcast_arrays(shapes, data):
 
     out = xp.broadcast_arrays(*arrays)
 
-    out_shape = broadcast_shapes(*shapes)
+    out_shape = sh.broadcast_shapes(*shapes)
     for i, x in enumerate(arrays):
         ph.assert_dtype(
             "broadcast_arrays", x.dtype, out[i].dtype, repr_name=f"out[{i}].dtype"
@@ -90,7 +90,7 @@ def test_broadcast_to(x, data):
     shape = data.draw(
         hh.mutually_broadcastable_shapes(1, base_shape=x.shape)
         .map(lambda S: S[0])
-        .filter(lambda s: broadcast_shapes(x.shape, s) == s),
+        .filter(lambda s: sh.broadcast_shapes(x.shape, s) == s),
         label="shape",
     )
 

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -297,7 +297,7 @@ def test_matmul(x1, x2):
     else:
         res = _array_module.matmul(x1, x2)
 
-    ph.assert_dtype("matmul", (x1.dtype, x2.dtype), res.dtype)
+    ph.assert_dtype("matmul", [x1.dtype, x2.dtype], res.dtype)
 
     if len(x1.shape) == len(x2.shape) == 1:
         assert res.shape == ()

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -31,8 +31,6 @@ from . import dtype_helpers as dh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 
-from .algos import broadcast_shapes
-
 from . import _array_module
 from . import _array_module as xp
 from ._array_module import linalg
@@ -310,7 +308,7 @@ def test_matmul(x1, x2):
         assert res.shape == x1.shape[:-1]
         _test_stacks(_array_module.matmul, x1, x2, res=res, dims=1)
     else:
-        stack_shape = broadcast_shapes(x1.shape[:-2], x2.shape[:-2])
+        stack_shape = sh.broadcast_shapes(x1.shape[:-2], x2.shape[:-2])
         assert res.shape == stack_shape + (x1.shape[-2], x2.shape[-1])
         _test_stacks(_array_module.matmul, x1, x2, res=res)
 

--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -142,7 +142,7 @@ def test_expand_dims(x, axis):
     index = axis if axis >= 0 else x.ndim + axis + 1
     shape.insert(index, 1)
     shape = tuple(shape)
-    ph.assert_result_shape("expand_dims", (x.shape,), out.shape, shape)
+    ph.assert_result_shape("expand_dims", [x.shape], out.shape, shape)
 
     assert_array_ndindex(
         "expand_dims", x, sh.ndindex(x.shape), out, sh.ndindex(out.shape)
@@ -181,7 +181,7 @@ def test_squeeze(x, data):
         if i not in axes:
             shape.append(side)
     shape = tuple(shape)
-    ph.assert_result_shape("squeeze", (x.shape,), out.shape, shape, axis=axis)
+    ph.assert_result_shape("squeeze", [x.shape], out.shape, shape, axis=axis)
 
     assert_array_ndindex("squeeze", x, sh.ndindex(x.shape), out, sh.ndindex(out.shape))
 
@@ -230,7 +230,7 @@ def test_permute_dims(x, axes):
         side = x.shape[dim]
         shape[i] = side
     shape = tuple(shape)
-    ph.assert_result_shape("permute_dims", (x.shape,), out.shape, shape, axes=axes)
+    ph.assert_result_shape("permute_dims", [x.shape], out.shape, shape, axes=axes)
 
     indices = list(sh.ndindex(x.shape))
     permuted_indices = [tuple(idx[axis] for axis in axes) for idx in indices]
@@ -265,7 +265,7 @@ def test_reshape(x, data):
         rsize = math.prod(shape) * -1
         _shape[shape.index(-1)] = size / rsize
     _shape = tuple(_shape)
-    ph.assert_result_shape("reshape", (x.shape,), out.shape, _shape, shape=shape)
+    ph.assert_result_shape("reshape", [x.shape], out.shape, _shape, shape=shape)
 
     assert_array_ndindex("reshape", x, sh.ndindex(x.shape), out, sh.ndindex(out.shape))
 
@@ -303,7 +303,7 @@ def test_roll(x, data):
 
     ph.assert_dtype("roll", x.dtype, out.dtype)
 
-    ph.assert_result_shape("roll", (x.shape,), out.shape)
+    ph.assert_result_shape("roll", [x.shape], out.shape)
 
     if kw.get("axis", None) is None:
         assert isinstance(shift, int)  # sanity check

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -66,14 +66,12 @@ def unary_assert_against_refimpl(
     res: Array,
     refimpl: Callable[[Scalar], Scalar],
     expr_template: str,
-    in_stype: Optional[ScalarType] = None,
     res_stype: Optional[ScalarType] = None,
     filter_: Callable[[Scalar], bool] = math.isfinite,
 ):
     if in_.shape != res.shape:
         raise ValueError(f"{res.shape=}, but should be {in_.shape=}")
-    if in_stype is None:
-        in_stype = dh.get_scalar_type(in_.dtype)
+    in_stype = dh.get_scalar_type(in_.dtype)
     if res_stype is None:
         res_stype = in_stype
     m, M = dh.dtype_ranges.get(res.dtype, (None, None))
@@ -109,15 +107,13 @@ def binary_assert_against_refimpl(
     res: Array,
     refimpl: Callable[[Scalar, Scalar], Scalar],
     expr_template: str,
-    in_stype: Optional[ScalarType] = None,
     res_stype: Optional[ScalarType] = None,
     left_sym: str = "x1",
     right_sym: str = "x2",
     res_name: str = "out",
     filter_: Callable[[Scalar], bool] = math.isfinite,
 ):
-    if in_stype is None:
-        in_stype = dh.get_scalar_type(left.dtype)
+    in_stype = dh.get_scalar_type(left.dtype)
     if res_stype is None:
         res_stype = in_stype
     m, M = dh.dtype_ranges.get(res.dtype, (None, None))
@@ -350,14 +346,12 @@ def binary_param_assert_against_refimpl(
     res: Array,
     refimpl: Callable[[Scalar, Scalar], Scalar],
     expr_template: str,
-    in_stype: Optional[ScalarType] = None,
     res_stype: Optional[ScalarType] = None,
     filter_: Callable[[Scalar], bool] = math.isfinite,
 ):
     if ctx.right_is_scalar:
         assert filter_(right)  # sanity check
-        if in_stype is None:
-            in_stype = dh.get_scalar_type(left.dtype)
+        in_stype = dh.get_scalar_type(left.dtype)
         if res_stype is None:
             res_stype = in_stype
         m, M = dh.dtype_ranges.get(left.dtype, (None, None))
@@ -389,7 +383,6 @@ def binary_param_assert_against_refimpl(
     else:
         binary_assert_against_refimpl(
             func_name=ctx.func_name,
-            in_stype=in_stype,
             left_sym=ctx.left_sym,
             left=left,
             right_sym=ctx.right_sym,

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -287,9 +287,9 @@ def assert_binary_param_shape(
     expected: Optional[Shape] = None,
 ):
     if ctx.right_is_scalar:
-        in_shapes = (left.shape,)
+        in_shapes = [left.shape]
     else:
-        in_shapes = (left.shape, right.shape)  # type: ignore
+        in_shapes = [left.shape, right.shape]  # type: ignore
     ph.assert_result_shape(
         ctx.func_name, in_shapes, res.shape, expected, repr_name=f"{ctx.res_name}.shape"
     )
@@ -444,7 +444,7 @@ def test_atan(x):
 def test_atan2(x1, x2):
     out = xp.atan2(x1, x2)
     ph.assert_dtype("atan2", [x1.dtype, x2.dtype], out.dtype)
-    ph.assert_result_shape("atan2", (x1.shape, x2.shape), out.shape)
+    ph.assert_result_shape("atan2", [x1.shape, x2.shape], out.shape)
     INFINITY1 = ah.infinity(x1.shape, x1.dtype)
     INFINITY2 = ah.infinity(x2.shape, x2.dtype)
     PI = ah.π(out.shape, out.dtype)
@@ -1304,7 +1304,7 @@ def test_logaddexp(x1, x2):
 def test_logical_and(x1, x2):
     out = ah.logical_and(x1, x2)
     ph.assert_dtype("logical_and", [x1.dtype, x2.dtype], out.dtype)
-    ph.assert_result_shape("logical_and", (x1.shape, x2.shape), out.shape)
+    ph.assert_result_shape("logical_and", [x1.shape, x2.shape], out.shape)
     binary_assert_against_refimpl(
         "logical_and",
         bool,
@@ -1330,7 +1330,7 @@ def test_logical_not(x):
 def test_logical_or(x1, x2):
     out = ah.logical_or(x1, x2)
     ph.assert_dtype("logical_or", [x1.dtype, x2.dtype], out.dtype)
-    ph.assert_result_shape("logical_or", (x1.shape, x2.shape), out.shape)
+    ph.assert_result_shape("logical_or", [x1.shape, x2.shape], out.shape)
     binary_assert_against_refimpl(
         "logical_or", bool, x1, x2, out, lambda l, r: l or r, "({} or {})={}"
     )
@@ -1340,7 +1340,7 @@ def test_logical_or(x1, x2):
 def test_logical_xor(x1, x2):
     out = xp.logical_xor(x1, x2)
     ph.assert_dtype("logical_xor", [x1.dtype, x2.dtype], out.dtype)
-    ph.assert_result_shape("logical_xor", (x1.shape, x2.shape), out.shape)
+    ph.assert_result_shape("logical_xor", [x1.shape, x2.shape], out.shape)
     binary_assert_against_refimpl(
         "logical_xor", bool, x1, x2, out, lambda l, r: l ^ r, "({} ^ {})={}"
     )

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -79,7 +79,10 @@ def unary_assert_against_refimpl(
         scalar_i = in_stype(in_[idx])
         if not filter_(scalar_i):
             continue
-        expected = refimpl(scalar_i)
+        try:
+            expected = refimpl(scalar_i)
+        except OverflowError:
+            continue
         if res.dtype != xp.bool:
             assert m is not None and M is not None  # for mypy
             if expected <= m or expected >= M:
@@ -122,7 +125,10 @@ def binary_assert_against_refimpl(
         scalar_r = in_stype(right[r_idx])
         if not (filter_(scalar_l) and filter_(scalar_r)):
             continue
-        expected = refimpl(scalar_l, scalar_r)
+        try:
+            expected = refimpl(scalar_l, scalar_r)
+        except OverflowError:
+            continue
         if res.dtype != xp.bool:
             assert m is not None and M is not None  # for mypy
             if expected <= m or expected >= M:
@@ -359,7 +365,10 @@ def binary_param_assert_against_refimpl(
             scalar_l = in_stype(left[idx])
             if not filter_(scalar_l):
                 continue
-            expected = refimpl(scalar_l, right)
+            try:
+                expected = refimpl(scalar_l, right)
+            except OverflowError:
+                continue
             if left.dtype != xp.bool:
                 assert m is not None and M is not None  # for mypy
                 if expected <= m or expected >= M:

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -63,7 +63,8 @@ def mock_int_dtype(n: int, dtype: DataType) -> int:
 # By default, floating-point functions/methods are loosely asserted against. Use
 # `strict_check=True` when they should be strictly asserted against, i.e.
 # when a function should return intergrals. Likewise, use `strict_check=False`
-# when integer function/methods should be loosely asserted against.
+# when integer function/methods should be loosely asserted against, i.e. when
+# floats are used internally for optimisation or legacy reasons.
 
 
 def isclose(a: float, b: float, rel_tol: float = 0.25, abs_tol: float = 1) -> bool:

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -273,7 +273,7 @@ def assert_binary_param_dtype(
     if ctx.right_is_scalar:
         in_dtypes = left.dtype
     else:
-        in_dtypes = (left.dtype, right.dtype)  # type: ignore
+        in_dtypes = [left.dtype, right.dtype]  # type: ignore
     ph.assert_dtype(
         ctx.func_name, in_dtypes, res.dtype, expected, repr_name=f"{ctx.res_name}.dtype"
     )
@@ -443,7 +443,7 @@ def test_atan(x):
 @given(*hh.two_mutual_arrays(dh.float_dtypes))
 def test_atan2(x1, x2):
     out = xp.atan2(x1, x2)
-    ph.assert_dtype("atan2", (x1.dtype, x2.dtype), out.dtype)
+    ph.assert_dtype("atan2", [x1.dtype, x2.dtype], out.dtype)
     ph.assert_result_shape("atan2", (x1.shape, x2.shape), out.shape)
     INFINITY1 = ah.infinity(x1.shape, x1.dtype)
     INFINITY2 = ah.infinity(x2.shape, x2.dtype)
@@ -1294,7 +1294,7 @@ def test_log10(x):
 @given(*hh.two_mutual_arrays(dh.float_dtypes))
 def test_logaddexp(x1, x2):
     out = xp.logaddexp(x1, x2)
-    ph.assert_dtype("logaddexp", (x1.dtype, x2.dtype), out.dtype)
+    ph.assert_dtype("logaddexp", [x1.dtype, x2.dtype], out.dtype)
     # The spec doesn't require any behavior for this function. We could test
     # that this is indeed an approximation of log(exp(x1) + exp(x2)), but we
     # don't have tests for this sort of thing for any functions yet.
@@ -1303,7 +1303,7 @@ def test_logaddexp(x1, x2):
 @given(*hh.two_mutual_arrays([xp.bool]))
 def test_logical_and(x1, x2):
     out = ah.logical_and(x1, x2)
-    ph.assert_dtype("logical_and", (x1.dtype, x2.dtype), out.dtype)
+    ph.assert_dtype("logical_and", [x1.dtype, x2.dtype], out.dtype)
     ph.assert_result_shape("logical_and", (x1.shape, x2.shape), out.shape)
     binary_assert_against_refimpl(
         "logical_and",
@@ -1329,7 +1329,7 @@ def test_logical_not(x):
 @given(*hh.two_mutual_arrays([xp.bool]))
 def test_logical_or(x1, x2):
     out = ah.logical_or(x1, x2)
-    ph.assert_dtype("logical_or", (x1.dtype, x2.dtype), out.dtype)
+    ph.assert_dtype("logical_or", [x1.dtype, x2.dtype], out.dtype)
     ph.assert_result_shape("logical_or", (x1.shape, x2.shape), out.shape)
     binary_assert_against_refimpl(
         "logical_or", bool, x1, x2, out, lambda l, r: l or r, "({} or {})={}"
@@ -1339,7 +1339,7 @@ def test_logical_or(x1, x2):
 @given(*hh.two_mutual_arrays([xp.bool]))
 def test_logical_xor(x1, x2):
     out = xp.logical_xor(x1, x2)
-    ph.assert_dtype("logical_xor", (x1.dtype, x2.dtype), out.dtype)
+    ph.assert_dtype("logical_xor", [x1.dtype, x2.dtype], out.dtype)
     ph.assert_result_shape("logical_xor", (x1.shape, x2.shape), out.shape)
     binary_assert_against_refimpl(
         "logical_xor", bool, x1, x2, out, lambda l, r: l ^ r, "({} ^ {})={}"

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1,7 +1,7 @@
 import math
 import operator
 from enum import Enum, auto
-from typing import Callable, List, NamedTuple, Optional, Union
+from typing import Callable, List, NamedTuple, Optional, TypeVar, Union
 
 import pytest
 from hypothesis import assume, given
@@ -85,11 +85,14 @@ def default_filter(s: Scalar) -> bool:
     return math.isfinite(s) and s is not -0.0 and s is not +0.0
 
 
+T = TypeVar("T")
+
+
 def unary_assert_against_refimpl(
     func_name: str,
     in_: Array,
     res: Array,
-    refimpl: Callable[[Scalar], Scalar],
+    refimpl: Callable[[T], T],
     expr_template: Optional[str] = None,
     res_stype: Optional[ScalarType] = None,
     filter_: Callable[[Scalar], bool] = default_filter,
@@ -136,7 +139,7 @@ def binary_assert_against_refimpl(
     left: Array,
     right: Array,
     res: Array,
-    refimpl: Callable[[Scalar, Scalar], Scalar],
+    refimpl: Callable[[T, T], T],
     expr_template: Optional[str] = None,
     res_stype: Optional[ScalarType] = None,
     left_sym: str = "x1",
@@ -382,7 +385,7 @@ def binary_param_assert_against_refimpl(
     right: Union[Array, Scalar],
     res: Array,
     op_sym: str,
-    refimpl: Callable[[Scalar, Scalar], Scalar],
+    refimpl: Callable[[T, T], T],
     res_stype: Optional[ScalarType] = None,
     filter_: Callable[[Scalar], bool] = default_filter,
     strict_check: Optional[bool] = None,
@@ -456,7 +459,7 @@ def test_abs(ctx, data):
         ctx.func_name,
         x,
         out,
-        abs,
+        abs,  # type: ignore
         expr_template="abs({})={}",
         filter_=lambda s: (
             s == float("infinity") or (math.isfinite(s) and s is not -0.0)
@@ -1013,7 +1016,7 @@ def test_negative(ctx, data):
     ph.assert_dtype(ctx.func_name, x.dtype, out.dtype)
     ph.assert_shape(ctx.func_name, out.shape, x.shape)
     unary_assert_against_refimpl(
-        ctx.func_name, x, out, operator.neg, expr_template="-({})={}"
+        ctx.func_name, x, out, operator.neg, expr_template="-({})={}"  # type: ignore
     )
 
 

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1473,7 +1473,23 @@ def test_sign(x):
     out = xp.sign(x)
     ph.assert_dtype("sign", x.dtype, out.dtype)
     ph.assert_shape("sign", out.shape, x.shape)
-    # TODO
+    scalar_type = dh.get_scalar_type(x.dtype)
+    for idx in sh.ndindex(x.shape):
+        scalar_x = scalar_type(x[idx])
+        f_x = sh.fmt_idx("x", idx)
+        if math.isnan(scalar_x):
+            continue
+        if scalar_x == 0:
+            expected = 0
+            expr = f"{f_x}=0"
+        else:
+            expected = 1 if scalar_x > 0 else -1
+            expr = f"({f_x} / |{f_x}|)={expected}"
+        scalar_o = scalar_type(out[idx])
+        f_o = sh.fmt_idx("out", idx)
+        assert scalar_o == expected, (
+            f"{f_o}={scalar_o}, but should be {expr} [sign()]\n{f_x}={scalar_x}"
+        )
 
 
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -446,30 +446,24 @@ def test_abs(ctx, data):
     )
 
 
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(),
-        shape=hh.shapes(),
-        elements={"min_value": -1, "max_value": 1},
-    )
-)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_acos(x):
     out = xp.acos(x)
     ph.assert_dtype("acos", x.dtype, out.dtype)
     ph.assert_shape("acos", out.shape, x.shape)
-    unary_assert_against_refimpl("acos", x, out, math.acos)
-
-
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(), shape=hh.shapes(), elements={"min_value": 1}
+    unary_assert_against_refimpl(
+        "acos", x, out, math.acos, filter_=lambda s: default_filter(s) and -1 <= s <= 1
     )
-)
+
+
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_acosh(x):
     out = xp.acosh(x)
     ph.assert_dtype("acosh", x.dtype, out.dtype)
     ph.assert_shape("acosh", out.shape, x.shape)
-    unary_assert_against_refimpl("acosh", x, out, math.acosh)
+    unary_assert_against_refimpl(
+        "acosh", x, out, math.acosh, filter_=lambda s: default_filter(s) and s >= 1
+    )
 
 
 @pytest.mark.parametrize("ctx,", make_binary_params("add", xps.numeric_dtypes()))
@@ -488,18 +482,14 @@ def test_add(ctx, data):
     binary_param_assert_against_refimpl(ctx, left, right, res, "+", operator.add)
 
 
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(),
-        shape=hh.shapes(),
-        elements={"min_value": -1, "max_value": 1},
-    )
-)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_asin(x):
     out = xp.asin(x)
     ph.assert_dtype("asin", x.dtype, out.dtype)
     ph.assert_shape("asin", out.shape, x.shape)
-    unary_assert_against_refimpl("asin", x, out, math.asin)
+    unary_assert_against_refimpl(
+        "asin", x, out, math.asin, filter_=lambda s: default_filter(s) and -1 <= s <= 1
+    )
 
 
 @given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
@@ -526,18 +516,18 @@ def test_atan2(x1, x2):
     binary_assert_against_refimpl("atan2", x1, x2, out, math.atan2)
 
 
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(),
-        shape=hh.shapes(),
-        elements={"min_value": -1, "max_value": 1},
-    )
-)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_atanh(x):
     out = xp.atanh(x)
     ph.assert_dtype("atanh", x.dtype, out.dtype)
     ph.assert_shape("atanh", out.shape, x.shape)
-    unary_assert_against_refimpl("atanh", x, out, math.atanh)
+    unary_assert_against_refimpl(
+        "atanh",
+        x,
+        out,
+        math.atanh,
+        filter_=lambda s: default_filter(s) and -1 <= s <= 1,
+    )
 
 
 @pytest.mark.parametrize(
@@ -899,56 +889,44 @@ def test_less_equal(ctx, data):
     )
 
 
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(), shape=hh.shapes(), elements={"min_value": 1}
-    )
-)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log(x):
     out = xp.log(x)
     ph.assert_dtype("log", x.dtype, out.dtype)
     ph.assert_shape("log", out.shape, x.shape)
-    unary_assert_against_refimpl("log", x, out, math.log)
-
-
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(), shape=hh.shapes(), elements={"min_value": 1}
+    unary_assert_against_refimpl(
+        "log", x, out, math.log, filter_=lambda s: default_filter(s) and s >= 1
     )
-)
+
+
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log1p(x):
     out = xp.log1p(x)
     ph.assert_dtype("log1p", x.dtype, out.dtype)
     ph.assert_shape("log1p", out.shape, x.shape)
-    unary_assert_against_refimpl("log1p", x, out, math.log1p)
-
-
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(),
-        shape=hh.shapes(),
-        elements={"min_value": 0, "exclude_min": True},
+    unary_assert_against_refimpl(
+        "log1p", x, out, math.log1p, filter_=lambda s: default_filter(s) and s >= 1
     )
-)
+
+
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log2(x):
     out = xp.log2(x)
     ph.assert_dtype("log2", x.dtype, out.dtype)
     ph.assert_shape("log2", out.shape, x.shape)
-    unary_assert_against_refimpl("log2", x, out, math.log2)
-
-
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(),
-        shape=hh.shapes(),
-        elements={"min_value": 0, "exclude_min": True},
+    unary_assert_against_refimpl(
+        "log2", x, out, math.log2, filter_=lambda s: default_filter(s) and s > 1
     )
-)
+
+
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_log10(x):
     out = xp.log10(x)
     ph.assert_dtype("log10", x.dtype, out.dtype)
     ph.assert_shape("log10", out.shape, x.shape)
-    unary_assert_against_refimpl("log10", x, out, math.log10)
+    unary_assert_against_refimpl(
+        "log10", x, out, math.log10, filter_=lambda s: default_filter(s) and s > 0
+    )
 
 
 @given(*hh.two_mutual_arrays(dh.float_dtypes))
@@ -1166,16 +1144,14 @@ def test_square(x):
     )
 
 
-@given(
-    xps.arrays(
-        dtype=xps.floating_dtypes(), shape=hh.shapes(), elements={"min_value": 0}
-    )
-)
+@given(xps.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
 def test_sqrt(x):
     out = xp.sqrt(x)
     ph.assert_dtype("sqrt", x.dtype, out.dtype)
     ph.assert_shape("sqrt", out.shape, x.shape)
-    unary_assert_against_refimpl("sqrt", x, out, math.sqrt)
+    unary_assert_against_refimpl(
+        "sqrt", x, out, math.sqrt, filter_=lambda s: default_filter(s) and s >= 0
+    )
 
 
 @pytest.mark.parametrize("ctx", make_binary_params("subtract", xps.numeric_dtypes()))

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1221,13 +1221,19 @@ def test_logaddexp(x1, x2):
 def test_logical_and(x1, x2):
     out = ah.logical_and(x1, x2)
     ph.assert_dtype("logical_and", (x1.dtype, x2.dtype), out.dtype)
-    # See the comments in test_equal
-    shape = sh.broadcast_shapes(x1.shape, x2.shape)
-    ph.assert_shape("logical_and", out.shape, shape)
-    _x1 = xp.broadcast_to(x1, shape)
-    _x2 = xp.broadcast_to(x2, shape)
-    for idx in sh.ndindex(shape):
-        assert out[idx] == (bool(_x1[idx]) and bool(_x2[idx]))
+    ph.assert_result_shape("logical_and", (x1.shape, x2.shape), out.shape)
+    for l_idx, r_idx, o_idx in sh.iter_indices(x1.shape, x2.shape, out.shape):
+        scalar_l = bool(x1[l_idx])
+        scalar_r = bool(x2[r_idx])
+        expected = scalar_l and scalar_r
+        scalar_o = bool(out[o_idx])
+        f_l = sh.fmt_idx("x1", l_idx)
+        f_r = sh.fmt_idx("x2", r_idx)
+        f_o = sh.fmt_idx("out", o_idx)
+        assert scalar_o == expected, (
+            f"{f_o}={scalar_o}, but should be ({f_l} and {f_r})={expected} "
+            f"[logical_and()]\n{f_l}={scalar_l}, {f_r}={scalar_r}"
+        )
 
 
 @given(xps.arrays(dtype=xp.bool, shape=hh.shapes()))

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -25,7 +25,6 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
-from .algos import broadcast_shapes
 from .typing import Array, DataType, Param, Scalar, Shape
 
 pytestmark = pytest.mark.ci
@@ -1223,7 +1222,7 @@ def test_logical_and(x1, x2):
     out = ah.logical_and(x1, x2)
     ph.assert_dtype("logical_and", (x1.dtype, x2.dtype), out.dtype)
     # See the comments in test_equal
-    shape = broadcast_shapes(x1.shape, x2.shape)
+    shape = sh.broadcast_shapes(x1.shape, x2.shape)
     ph.assert_shape("logical_and", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
@@ -1245,7 +1244,7 @@ def test_logical_or(x1, x2):
     out = ah.logical_or(x1, x2)
     ph.assert_dtype("logical_or", (x1.dtype, x2.dtype), out.dtype)
     # See the comments in test_equal
-    shape = broadcast_shapes(x1.shape, x2.shape)
+    shape = sh.broadcast_shapes(x1.shape, x2.shape)
     ph.assert_shape("logical_or", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)
@@ -1258,7 +1257,7 @@ def test_logical_xor(x1, x2):
     out = xp.logical_xor(x1, x2)
     ph.assert_dtype("logical_xor", (x1.dtype, x2.dtype), out.dtype)
     # See the comments in test_equal
-    shape = broadcast_shapes(x1.shape, x2.shape)
+    shape = sh.broadcast_shapes(x1.shape, x2.shape)
     ph.assert_shape("logical_xor", out.shape, shape)
     _x1 = xp.broadcast_to(x1, shape)
     _x2 = xp.broadcast_to(x2, shape)

--- a/array_api_tests/test_searching_functions.py
+++ b/array_api_tests/test_searching_functions.py
@@ -8,7 +8,6 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
-from .algos import broadcast_shapes
 
 pytestmark = pytest.mark.ci
 
@@ -134,7 +133,7 @@ def test_where(shapes, dtypes, data):
 
     out = xp.where(cond, x1, x2)
 
-    shape = broadcast_shapes(*shapes)
+    shape = sh.broadcast_shapes(*shapes)
     ph.assert_shape("where", out.shape, shape)
     # TODO: generate indices without broadcasting arrays
     _cond = xp.broadcast_to(cond, shape)

--- a/array_api_tests/test_set_functions.py
+++ b/array_api_tests/test_set_functions.py
@@ -1,8 +1,8 @@
 # TODO: disable if opted out, refactor things
 import math
-import pytest
 from collections import Counter, defaultdict
 
+import pytest
 from hypothesis import assume, given
 
 from . import _array_module as xp

--- a/array_api_tests/test_sorting_functions.py
+++ b/array_api_tests/test_sorting_functions.py
@@ -1,7 +1,7 @@
 import math
-import pytest
 from typing import Set
 
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.control import assume

--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -1,7 +1,7 @@
 import math
-import pytest
 from typing import Optional
 
+import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.control import reject

--- a/array_api_tests/test_type_promotion.py
+++ b/array_api_tests/test_type_promotion.py
@@ -271,7 +271,7 @@ def test_op_scalar_promotion(op, expr, in_dtype, in_stype, out_dtype, data):
         out = eval(expr, {"x": x, "s": s})
     except OverflowError:
         reject()
-    ph.assert_dtype(op, (in_dtype, in_stype), out.dtype, out_dtype)
+    ph.assert_dtype(op, [in_dtype, in_stype], out.dtype, out_dtype)
 
 
 inplace_scalar_params: List[Param[str, str, DataType, ScalarType]] = []
@@ -307,7 +307,7 @@ def test_inplace_op_scalar_promotion(op, expr, dtype, in_stype, data):
         reject()
     x = locals_["x"]
     assert x.dtype == dtype, f"{x.dtype=!s}, but should be {dtype}"
-    ph.assert_dtype(op, (dtype, in_stype), x.dtype, dtype, repr_name="x.dtype")
+    ph.assert_dtype(op, [dtype, in_stype], x.dtype, dtype, repr_name="x.dtype")
 
 
 if __name__ == "__main__":

--- a/array_api_tests/typing.py
+++ b/array_api_tests/typing.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Type, Union, Any
+from typing import Any, Tuple, Type, Union
 
 __all__ = [
     "DataType",
@@ -6,6 +6,8 @@ __all__ = [
     "ScalarType",
     "Array",
     "Shape",
+    "AtomicIndex",
+    "Index",
     "Param",
 ]
 
@@ -14,4 +16,6 @@ Scalar = Union[bool, int, float]
 ScalarType = Union[Type[bool], Type[int], Type[float]]
 Array = Any
 Shape = Tuple[int, ...]
+AtomicIndex = Union[int, "ellipsis", slice]  # noqa
+Index = Union[AtomicIndex, Tuple[AtomicIndex, ...]]
 Param = Tuple


### PR DESCRIPTION
This PR:
- Utilities `ndindex.iter_indices()` to greatly improve values testing
  - This is used for _every_ test via the newly introduced `*_assert_against_refimpl()` utils
- Implement values testing for **all** remaining op/elwise tests
- Test scalar scenarios for binary parametrized tests  (i.e. the ones that cover both operators and elementwise functions)
- Greatly improves error output (no more million random variables popping up when there's an error)


Additionally:
- Resolves #71 with `sh.fmt_idx()`
- Resolves #84 