### PR TITLE
Revamped signature tests

### DIFF
--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -245,7 +245,8 @@ def result_type(*dtypes: DataType):
     return result
 
 
-r_in_dtypes = re.compile("x1?: array\n.+Should have an? (.+) data type.")
+r_alias = re.compile("[aA]lias")
+r_in_dtypes = re.compile("x1?: array\n.+have an? (.+) data type.")
 r_int_note = re.compile(
     "If one or both of the input arrays have integer data types, "
     "the result is implementation-dependent"
@@ -331,6 +332,8 @@ func_returns_bool = {
     "trunc": False,
     # searching
     "where": False,
+    # linalg
+    "matmul": False,
 }
 
 
@@ -374,7 +377,7 @@ op_to_func = {
     "__gt__": "greater",
     "__le__": "less_equal",
     "__lt__": "less",
-    # '__matmul__': 'matmul',  # TODO: support matmul
+    "__matmul__": "matmul",
     "__mod__": "remainder",
     "__mul__": "multiply",
     "__ne__": "not_equal",
@@ -410,6 +413,7 @@ func_in_dtypes["__bool__"] = (xp.bool,)
 func_in_dtypes["__int__"] = all_int_dtypes
 func_in_dtypes["__index__"] = all_int_dtypes
 func_in_dtypes["__float__"] = float_dtypes
+func_in_dtypes["from_dlpack"] = numeric_dtypes
 func_in_dtypes["__dlpack__"] = numeric_dtypes
 
 

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -267,6 +267,8 @@ for name, func in name_to_func.items():
         func_in_dtypes[name] = dtypes
     elif any("x" in name for name in signature(func).parameters.keys()):
         func_in_dtypes[name] = all_dtypes
+# See https://github.com/data-apis/array-api/pull/413
+func_in_dtypes["expm1"] = float_dtypes
 
 
 func_returns_bool = {

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -406,6 +406,13 @@ for op, symbol in binary_op_to_symbol.items():
     func_returns_bool[iop] = func_returns_bool[op]
 
 
+func_in_dtypes["__bool__"] = (xp.bool,)
+func_in_dtypes["__int__"] = all_int_dtypes
+func_in_dtypes["__index__"] = all_int_dtypes
+func_in_dtypes["__float__"] = float_dtypes
+func_in_dtypes["__dlpack__"] = numeric_dtypes
+
+
 @lru_cache
 def fmt_types(types: Tuple[Union[DataType, ScalarType], ...]) -> str:
     f_types = []

--- a/array_api_tests/meta/test_signatures.py
+++ b/array_api_tests/meta/test_signatures.py
@@ -1,0 +1,20 @@
+from inspect import signature
+
+import pytest
+
+from ..test_signatures import _test_inspectable_func
+
+
+@pytest.mark.xfail("not implemented")
+def test_kwonly():
+    def func(*, foo=None, bar=None):
+        pass
+
+    sig = signature(func)
+    _test_inspectable_func(sig, sig)
+
+    def reversed_func(*, bar=None, foo=None):
+        pass
+
+    reversed_sig = signature(reversed_func)
+    _test_inspectable_func(sig, reversed_sig)

--- a/array_api_tests/meta/test_signatures.py
+++ b/array_api_tests/meta/test_signatures.py
@@ -29,16 +29,13 @@ stub_sig = signature(stub)
                 Parameter("baz", Parameter.POSITIONAL_OR_KEYWORD),
             ]
         ),
-        pytest.param(
-            Signature(
-                [
-                    Parameter("foo", Parameter.POSITIONAL_ONLY),
-                    Parameter("bar", Parameter.POSITIONAL_OR_KEYWORD),
-                    Parameter("qux", Parameter.KEYWORD_ONLY),
-                    Parameter("baz", Parameter.KEYWORD_ONLY),
-                ]
-            ),
-            marks=pytest.mark.xfail(reason="out-of-order kwonly args not supported"),
+        Signature(
+            [
+                Parameter("foo", Parameter.POSITIONAL_ONLY),
+                Parameter("bar", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter("qux", Parameter.KEYWORD_ONLY),
+                Parameter("baz", Parameter.KEYWORD_ONLY),
+            ]
         ),
     ],
 )

--- a/array_api_tests/meta/test_signatures.py
+++ b/array_api_tests/meta/test_signatures.py
@@ -1,20 +1,70 @@
-from inspect import signature
+from inspect import Parameter, Signature, signature
 
 import pytest
 
 from ..test_signatures import _test_inspectable_func
 
 
-@pytest.mark.xfail("not implemented")
-def test_kwonly():
-    def func(*, foo=None, bar=None):
-        pass
+def stub(foo, /, bar=None, *, baz=None):
+    pass
 
-    sig = signature(func)
-    _test_inspectable_func(sig, sig)
 
-    def reversed_func(*, bar=None, foo=None):
-        pass
+stub_sig = signature(stub)
 
-    reversed_sig = signature(reversed_func)
-    _test_inspectable_func(sig, reversed_sig)
+
+@pytest.mark.parametrize(
+    "sig",
+    [
+        Signature(
+            [
+                Parameter("foo", Parameter.POSITIONAL_ONLY),
+                Parameter("bar", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter("baz", Parameter.KEYWORD_ONLY),
+            ]
+        ),
+        Signature(
+            [
+                Parameter("foo", Parameter.POSITIONAL_ONLY),
+                Parameter("bar", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter("baz", Parameter.POSITIONAL_OR_KEYWORD),
+            ]
+        ),
+        pytest.param(
+            Signature(
+                [
+                    Parameter("foo", Parameter.POSITIONAL_ONLY),
+                    Parameter("bar", Parameter.POSITIONAL_OR_KEYWORD),
+                    Parameter("qux", Parameter.KEYWORD_ONLY),
+                    Parameter("baz", Parameter.KEYWORD_ONLY),
+                ]
+            ),
+            marks=pytest.mark.xfail(reason="out-of-order kwonly args not supported"),
+        ),
+    ],
+)
+def test_good_sig_passes(sig):
+    _test_inspectable_func(sig, stub_sig)
+
+
+@pytest.mark.parametrize(
+    "sig",
+    [
+        Signature(
+            [
+                Parameter("foo", Parameter.POSITIONAL_ONLY),
+                Parameter("bar", Parameter.POSITIONAL_ONLY),
+                Parameter("baz", Parameter.KEYWORD_ONLY),
+            ]
+        ),
+        Signature(
+            [
+                Parameter("foo", Parameter.POSITIONAL_ONLY),
+                Parameter("bar", Parameter.KEYWORD_ONLY),
+                Parameter("baz", Parameter.KEYWORD_ONLY),
+            ]
+        ),
+    ],
+)
+def test_raises_on_bad_sig(sig):
+    with pytest.raises(AssertionError):
+        _test_inspectable_func(sig, stub_sig)

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -1,282 +1,146 @@
-import inspect
-from itertools import chain
+from inspect import Parameter, Signature, signature
+from types import FunctionType
+from typing import Callable, Dict
 
 import pytest
+from hypothesis import given
 
-from ._array_module import mod, mod_name, ones, eye, float64, bool, int64, _UndefinedStub
-from .pytest_helpers import raises, doesnt_raise
-from . import dtype_helpers as dh
+from . import hypothesis_helpers as hh
+from . import xps
+from ._array_module import mod as xp
+from .stubs import array_methods, category_to_funcs, extension_to_funcs
 
-from . import stubs
+pytestmark = pytest.mark.ci
 
-
-def extension_module(name) -> bool:
-    for funcs in stubs.extension_to_funcs.values():
-        for func in funcs:
-            if name == func.__name__:
-                return True
-    else:
-        return False
-
-
-params = []
-for name in [f.__name__ for funcs in stubs.category_to_funcs.values() for f in funcs]:
-    if name in ["where", "expand_dims", "reshape"]:
-        params.append(pytest.param(name, marks=pytest.mark.skip(reason="faulty test")))
-    else:
-        params.append(name)
+kind_to_str: Dict[Parameter, str] = {
+    Parameter.POSITIONAL_OR_KEYWORD: "normal argument",
+    Parameter.POSITIONAL_ONLY: "pos-only argument",
+    Parameter.KEYWORD_ONLY: "keyword-only argument",
+    Parameter.VAR_POSITIONAL: "star-args (i.e. *args) argument",
+    Parameter.VAR_KEYWORD: "star-kwargs (i.e. **kwargs) argument",
+}
 
 
-for ext, name in [(ext, f.__name__) for ext, funcs in stubs.extension_to_funcs.items() for f in funcs]:
-    params.append(pytest.param(name, marks=pytest.mark.xp_extension(ext)))
-
-
-def array_method(name) -> bool:
-    return name in [f.__name__ for f in stubs.array_methods]
-
-def function_category(name) -> str:
-    for category, funcs in chain(stubs.category_to_funcs.items(), stubs.extension_to_funcs.items()):
-        for func in funcs:
-            if name == func.__name__:
-                return category
-
-def example_argument(arg, func_name, dtype):
+def _test_signature(
+    func: Callable, stub: FunctionType, ignore_first_stub_param: bool = False
+):
     """
-    Get an example argument for the argument arg for the function func_name
+    Signature of function is correct enough to not affect interoperability
 
-    The full tests for function behavior is in other files. We just need to
-    have an example input for each argument name that should work so that we
-    can check if the argument is implemented at all.
+    We're not interested in being 100% strict - instead we focus on areas which
+    could affect interop, e.g. with
+
+        def add(x1, x2, /):
+            ...
+
+    x1 and x2 don't need to be pos-only for the purposes of interoperability, but with
+
+        def squeeze(x, /, axis):
+            ...
+
+    axis has to be pos-or-keyword to support both styles
+
+        >>> squeeze(x, 0)
+        ...
+        >>> squeeze(x, axis=0)
+        ...
 
     """
-    # Note: for keyword arguments that have a default, this should be
-    # different from the default, as the default argument is tested separately
-    # (it can have the same behavior as the default, just not literally the
-    # same value).
-    known_args = dict(
-        api_version='2021.1',
-        arrays=(ones((1, 3, 3), dtype=dtype), ones((1, 3, 3), dtype=dtype)),
-        # These cannot be the same as each other, which is why all our test
-        # arrays have to have at least 3 dimensions.
-        axis1=2,
-        axis2=2,
-        axis=1,
-        axes=(2, 1, 0),
-        copy=True,
-        correction=1.0,
-        descending=True,
-        # TODO: This will only work on the NumPy implementation. The exact
-        # value of the device keyword will vary across implementations, so we
-        # need some way to infer it or for libraries to specify a list of
-        # valid devices.
-        device='cpu',
-        dtype=float64,
-        endpoint=False,
-        fill_value=1.0,
-        from_=int64,
-        full_matrices=False,
-        k=1,
-        keepdims=True,
-        key=(0, 0),
-        indexing='ij',
-        mode='complete',
-        n=2,
-        n_cols=1,
-        n_rows=1,
-        num=2,
-        offset=1,
-        ord=1,
-        obj = [[[1, 1, 1], [1, 1, 1], [1, 1, 1]]],
-        other=ones((3, 3), dtype=dtype),
-        return_counts=True,
-        return_index=True,
-        return_inverse=True,
-        rtol=1e-10,
-        self=ones((3, 3), dtype=dtype),
-        shape=(1, 3, 3),
-        shift=1,
-        sorted=False,
-        stable=False,
-        start=0,
-        step=2,
-        stop=1,
-        # TODO: Update this to be non-default. See the comment on "device" above.
-        stream=None,
-        to=float64,
-        type=float64,
-        upper=True,
-        value=0,
-        x1=ones((1, 3, 3), dtype=dtype),
-        x2=ones((1, 3, 3), dtype=dtype),
-        x=ones((1, 3, 3), dtype=dtype),
-    )
-    if not isinstance(bool, _UndefinedStub):
-        known_args['condition'] = ones((1, 3, 3), dtype=bool),
-
-    if arg in known_args:
-        # Special cases:
-
-        # squeeze() requires an axis of size 1, but other functions such as
-        # cross() require axes of size >1
-        if func_name == 'squeeze' and arg == 'axis':
-            return 0
-        # ones() is not invertible
-        # finfo requires a float dtype and iinfo requires an int dtype
-        elif func_name == 'iinfo' and arg == 'type':
-            return int64
-        # tensordot args must be contractible with each other
-        elif func_name == 'tensordot' and arg == 'x2':
-            return ones((3, 3, 1), dtype=dtype)
-        # tensordot "axes" is either a number representing the number of
-        # contractible axes or a 2-tuple or axes
-        elif func_name == 'tensordot' and arg == 'axes':
-            return 1
-        # The inputs to outer() must be 1-dimensional
-        elif func_name == 'outer' and arg in ['x1', 'x2']:
-            return ones((3,), dtype=dtype)
-        # Linear algebra functions tend to error if the input isn't "nice" as
-        # a matrix
-        elif arg.startswith('x') and func_name in [f.__name__ for f in stubs.extension_to_funcs["linalg"]]:
-            return eye(3)
-        return known_args[arg]
-    else:
-        raise RuntimeError(f"Don't know how to test argument {arg}. Please update test_signatures.py")
-
-@pytest.mark.parametrize('name', params)
-def test_has_names(name):
-    if extension_module(name):
-        ext = next(
-            ext for ext, funcs in stubs.extension_to_funcs.items()
-            if name in [f.__name__ for f in funcs]
+    try:
+        sig = signature(func)
+    except ValueError:
+        pytest.skip(
+            msg=f"type({stub.__name__})={type(func)} not supported by inspect.signature()"
         )
-        ext_mod = getattr(mod, ext)
-        assert hasattr(ext_mod, name), f"{mod_name} is missing the {function_category(name)} extension function {name}()"
-    elif array_method(name):
-        arr = ones((1, 1))
-        if name not in [f.__name__ for f in stubs.array_methods]:
-            assert hasattr(arr, name), f"The array object is missing the attribute {name}"
+    params = list(sig.parameters.values())
+
+    stub_sig = signature(stub)
+    stub_params = list(stub_sig.parameters.values())
+    if ignore_first_stub_param:
+        stub_params = stub_params[1:]
+        stub = Signature(
+            parameters=stub_params, return_annotation=stub_sig.return_annotation
+        )
+
+    # We're not interested if the array module has additional arguments, so we
+    # only iterate through the arguments listed in the spec.
+    for i, stub_param in enumerate(stub_params):
+        assert (
+            len(params) >= i + 1
+        ), f"Argument '{stub_param.name}' missing from signature"
+        param = params[i]
+
+        # We're not interested in the name if it isn't actually used
+        if stub_param.kind not in [
+            Parameter.POSITIONAL_ONLY,
+            Parameter.VAR_POSITIONAL,
+            Parameter.VAR_KEYWORD,
+        ]:
+            assert (
+                param.name == stub_param.name
+            ), f"Expected argument '{param.name}' to be named '{stub_param.name}'"
+
+        if (
+            stub_param.name in ["x", "x1", "x2"]
+            and stub_param.kind != Parameter.POSITIONAL_ONLY
+        ):
+            pytest.skip(
+                f"faulty spec - argument {stub_param.name} should be a "
+                f"{kind_to_str[Parameter.POSITIONAL_ONLY]}"
+            )
+        f_kind = kind_to_str[param.kind]
+        f_stub_kind = kind_to_str[stub_param.kind]
+        if stub_param.kind in [
+            Parameter.POSITIONAL_OR_KEYWORD,
+            Parameter.VAR_POSITIONAL,
+            Parameter.VAR_KEYWORD,
+        ]:
+            assert (
+                param.kind == stub_param.kind
+            ), f"{param.name} is a {f_kind}, but should be a {f_stub_kind}"
         else:
-            assert hasattr(arr, name), f"The array object is missing the method {name}()"
-    else:
-        assert hasattr(mod, name), f"{mod_name} is missing the {function_category(name)} function {name}()"
+            # TODO: allow for kw-only args to be out-of-order
+            assert param.kind in [stub_param.kind, Parameter.POSITIONAL_OR_KEYWORD], (
+                f"{param.name} is a {f_kind}, "
+                f"but should be a {f_stub_kind} "
+                f"(or at least a {kind_to_str[Parameter.POSITIONAL_OR_KEYWORD]})"
+            )
 
-@pytest.mark.parametrize('name', params)
-def test_function_positional_args(name):
-    # Note: We can't actually test that positional arguments are
-    # positional-only, as that would require knowing the argument name and
-    # checking that it can't be used as a keyword argument. But argument name
-    # inspection does not work for most array library functions that are not
-    # written in pure Python (e.g., it won't work for numpy ufuncs).
 
-    if extension_module(name):
-        return
+@pytest.mark.parametrize(
+    "stub",
+    [s for stubs in category_to_funcs.values() for s in stubs],
+    ids=lambda f: f.__name__,
+)
+def test_func_signature(stub: FunctionType):
+    assert hasattr(xp, stub.__name__), f"{stub.__name__} not found in array module"
+    func = getattr(xp, stub.__name__)
+    _test_signature(func, stub)
 
-    dtype = None
-    if (name.startswith('__i') and name not in ['__int__', '__invert__', '__index__']
-        or name.startswith('__r') and name != '__rshift__'):
-        n = f'__{name[3:]}'
-    else:
-        n = name
-    in_dtypes = dh.func_in_dtypes.get(n, dh.float_dtypes)
-    if bool in in_dtypes:
-        dtype = bool
-    elif all(d in in_dtypes for d in dh.all_int_dtypes):
-        dtype = int64
 
-    if array_method(name):
-        if name == '__bool__':
-            _mod = ones((), dtype=bool)
-        elif name in ['__int__', '__index__']:
-            _mod = ones((), dtype=int64)
-        elif name == '__float__':
-            _mod = ones((), dtype=float64)
-        else:
-            _mod = example_argument('self', name, dtype)
-    elif '.' in name:
-        extension_module_name, name = name.split('.')
-        _mod = getattr(mod, extension_module_name)
-    else:
-        _mod = mod
-    stub_func = stubs.name_to_func[name]
+extension_and_stub_params = []
+for ext, stubs in extension_to_funcs.items():
+    for stub in stubs:
+        p = pytest.param(
+            ext, stub, id=f"{ext}.{stub.__name__}", marks=pytest.mark.xp_extension(ext)
+        )
+        extension_and_stub_params.append(p)
 
-    if not hasattr(_mod, name):
-        pytest.skip(f"{mod_name} does not have {name}(), skipping.")
-    if stub_func is None:
-        # TODO: Can we make this skip the parameterization entirely?
-        pytest.skip(f"{name} is not a function, skipping.")
-    mod_func = getattr(_mod, name)
-    argspec = inspect.getfullargspec(stub_func)
-    func_args = argspec.args
-    if func_args[:1] == ['self']:
-        func_args = func_args[1:]
-    nargs = [len(func_args)]
-    if argspec.defaults:
-        # The actual default values are checked in the specific tests
-        nargs.extend([len(func_args) - i for i in range(1, len(argspec.defaults) + 1)])
 
-    args = [example_argument(arg, name, dtype) for arg in func_args]
-    if not args:
-        args = [example_argument('x', name, dtype)]
-    else:
-        # Duplicate the last positional argument for the n+1 test.
-        args = args + [args[-1]]
+@pytest.mark.parametrize("extension, stub", extension_and_stub_params)
+def test_extension_func_signature(extension: str, stub: FunctionType):
+    mod = getattr(xp, extension)
+    assert hasattr(
+        mod, stub.__name__
+    ), f"{stub.__name__} not found in {extension} extension"
+    func = getattr(mod, stub.__name__)
+    _test_signature(func, stub)
 
-    kwonlydefaults = argspec.kwonlydefaults or {}
-    required_kwargs = {arg: example_argument(arg, name, dtype) for arg in argspec.kwonlyargs if arg not in kwonlydefaults}
 
-    for n in range(nargs[0]+2):
-        if name == 'result_type' and n == 0:
-            # This case is not encoded in the signature, but isn't allowed.
-            continue
-        if n in nargs:
-            doesnt_raise(lambda: mod_func(*args[:n], **required_kwargs))
-        elif argspec.varargs:
-            pass
-        else:
-            # NumPy ufuncs raise ValueError instead of TypeError
-            raises((TypeError, ValueError), lambda: mod_func(*args[:n]), f"{name}() should not accept {n} positional arguments")
-
-@pytest.mark.parametrize('name', params)
-def test_function_keyword_only_args(name):
-    if extension_module(name):
-        return
-
-    if array_method(name):
-        _mod = ones((1, 1))
-    elif '.' in name:
-        extension_module_name, name = name.split('.')
-        _mod = getattr(mod, extension_module_name)
-    else:
-        _mod = mod
-    stub_func = stubs.name_to_func[name]
-
-    if not hasattr(_mod, name):
-        pytest.skip(f"{mod_name} does not have {name}(), skipping.")
-    if stub_func is None:
-        # TODO: Can we make this skip the parameterization entirely?
-        pytest.skip(f"{name} is not a function, skipping.")
-    mod_func = getattr(_mod, name)
-    argspec = inspect.getfullargspec(stub_func)
-    args = argspec.args
-    if args[:1] == ['self']:
-        args = args[1:]
-    kwonlyargs = argspec.kwonlyargs
-    kwonlydefaults = argspec.kwonlydefaults or {}
-    dtype = None
-
-    args = [example_argument(arg, name, dtype) for arg in args]
-
-    for arg in kwonlyargs:
-        value = example_argument(arg, name, dtype)
-        # The "only" part of keyword-only is tested by the positional test above.
-        doesnt_raise(lambda: mod_func(*args, **{arg: value}),
-                     f"{name}() should accept the keyword-only argument {arg!r}")
-
-        # Make sure the default is accepted. These tests are not granular
-        # enough to test that the default is actually the default, i.e., gives
-        # the same value if the keyword isn't passed. That is tested in the
-        # specific function tests.
-        if arg in kwonlydefaults:
-            default_value = kwonlydefaults[arg]
-            doesnt_raise(lambda: mod_func(*args, **{arg: default_value}),
-                         f"{name}() should accept the default value {default_value!r} for the keyword-only argument {arg!r}")
+@pytest.mark.parametrize("stub", array_methods, ids=lambda f: f.__name__)
+@given(x=xps.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()))
+def test_array_method_signature(stub: FunctionType, x):
+    assert hasattr(x, stub.__name__), f"{stub.__name__} not found in array object {x!r}"
+    method = getattr(x, stub.__name__)
+    # Ignore 'self' arg in stub, which won't be present in instantiated objects.
+    _test_signature(method, stub, ignore_first_stub_param=True)

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -19,13 +19,14 @@ axis has to be pos-or-keyword to support both styles
 
 """
 from collections import defaultdict
+from copy import copy
 from inspect import Parameter, Signature, signature
 from itertools import chain
 from types import FunctionType
-from typing import Callable, DefaultDict, Dict, List
+from typing import Any, Callable, DefaultDict, Dict, List, Literal, Sequence, get_args
 
 import pytest
-from hypothesis import given
+from hypothesis import given, note
 from hypothesis import strategies as st
 
 from . import dtype_helpers as dh
@@ -38,16 +39,22 @@ from .typing import DataType, Shape
 
 pytestmark = pytest.mark.ci
 
-
-kind_to_str: Dict[Parameter, str] = {
+ParameterKind = Literal[
+    Parameter.POSITIONAL_ONLY,
+    Parameter.VAR_POSITIONAL,
+    Parameter.POSITIONAL_OR_KEYWORD,
+    Parameter.KEYWORD_ONLY,
+    Parameter.VAR_KEYWORD,
+]
+ALL_KINDS = get_args(ParameterKind)
+VAR_KINDS = (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD)
+kind_to_str: Dict[ParameterKind, str] = {
     Parameter.POSITIONAL_OR_KEYWORD: "normal argument",
     Parameter.POSITIONAL_ONLY: "pos-only argument",
     Parameter.KEYWORD_ONLY: "keyword-only argument",
     Parameter.VAR_POSITIONAL: "star-args (i.e. *args) argument",
     Parameter.VAR_KEYWORD: "star-kwargs (i.e. **kwargs) argument",
 }
-
-VAR_KINDS = (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD)
 
 
 def _test_inspectable_func(sig: Signature, stub_sig: Signature):
@@ -89,10 +96,11 @@ def _test_inspectable_func(sig: Signature, stub_sig: Signature):
                 ], (
                     f"{param.name} is a {kind_to_str[param.kind]}, "
                     f"but should be a {f_stub_kind} "
-                    f"(or at least a {kind_to_str[Parameter.POSITIONAL_OR_KEYWORD]})"
+                    f"(or at least a {kind_to_str[ParameterKind.POSITIONAL_OR_KEYWORD]})"
                 )
             else:
                 pass
+
 
 def shapes(**kw) -> st.SearchStrategy[Shape]:
     if "min_side" not in kw.keys():
@@ -111,7 +119,7 @@ func_to_shapes: DefaultDict[str, st.SearchStrategy[Shape]] = defaultdict(
         **{k: st.just(()) for k in ["__bool__", "__int__", "__index__", "__float__"]},
         "sort": shapes(min_dims=1),  # for axis=-1,
         **{k: shapes(min_dims=2) for k in matrixy_funcs},
-        # Override for some matrixy functions
+        # Overwrite min_dims=2 shapes for some matrixy functions
         "cross": shapes(min_side=3, max_side=3, min_dims=3, max_dims=3),
         "outer": shapes(min_dims=1, max_dims=1),
     },
@@ -128,50 +136,98 @@ def get_dtypes_strategy(func_name: str) -> st.SearchStrategy[DataType]:
         return xps.scalar_dtypes()
 
 
+func_to_example_values: Dict[str, Dict[ParameterKind, Dict[str, Any]]] = {
+    "broadcast_to": {
+        Parameter.POSITIONAL_ONLY: {"x": xp.asarray([0, 1])},
+        Parameter.POSITIONAL_OR_KEYWORD: {"shape": (1, 2)},
+    },
+    "cholesky": {
+        Parameter.POSITIONAL_ONLY: {"x": xp.asarray([[1.0, 0.0], [0.0, 1.0]])}
+    },
+    "inv": {Parameter.POSITIONAL_ONLY: {"x": xp.asarray([[1.0, 0.0], [0.0, 1.0]])}},
+}
+
+
+def make_pretty_func(func_name: str, args: Sequence[Any], kwargs: Dict[str, Any]):
+    f_sig = f"{func_name}("
+    f_sig += ", ".join(str(a) for a in args)
+    if len(kwargs) != 0:
+        if len(args) != 0:
+            f_sig += ", "
+        f_sig += ", ".join(f"{k}={v}" for k, v in kwargs.items())
+    f_sig += ")"
+    return f_sig
+
+
 @given(data=st.data())
 def _test_uninspectable_func(func_name: str, func: Callable, stub_sig: Signature, data):
-    if func_name in ["cholesky", "inv"]:
-        func(xp.asarray([[1.0, 0.0], [0.0, 1.0]]))
-        return
-    elif func_name == "solve":
-        func(xp.asarray([[1.0, 2.0], [3.0, 5.0]]), xp.asarray([1.0, 2.0]))
-        return
+    example_values: Dict[ParameterKind, Dict[str, Any]] = func_to_example_values.get(
+        func_name, {}
+    )
+    for kind in ALL_KINDS:
+        example_values.setdefault(kind, {})
 
-    pos_argname_to_example_value = {}
-    normal_argname_to_example_value = {}
-    kw_argname_to_example_value = {}
-    for stub_param in stub_sig.parameters.values():
-        if stub_param.name in ["x", "x1"]:
+    for param in stub_sig.parameters.values():
+        for name_to_value in example_values.values():
+            if param.name in name_to_value.keys():
+                continue
+
+        if param.default != Parameter.empty:
+            example_value = param.default
+        elif param.name in ["x", "x1"]:
             dtypes = get_dtypes_strategy(func_name)
             shapes = func_to_shapes[func_name]
             example_value = data.draw(
-                xps.arrays(dtype=dtypes, shape=shapes), label=stub_param.name
+                xps.arrays(dtype=dtypes, shape=shapes), label=param.name
             )
-        elif stub_param.name == "x2":
-            assert "x1" in pos_argname_to_example_value.keys()  # sanity check
-            x1 = pos_argname_to_example_value["x1"]
+        elif param.name == "x2":
+            # sanity check
+            assert "x1" in example_values[Parameter.POSITIONAL_ONLY].keys()
+            x1 = example_values[Parameter.POSITIONAL_ONLY]["x1"]
             example_value = data.draw(
                 xps.arrays(dtype=x1.dtype, shape=x1.shape), label="x2"
             )
+        elif param.name == "axes":
+            example_value = ()
+        elif param.name == "shape":
+            example_value = ()
         else:
-            if stub_param.default != Parameter.empty:
-                example_value = stub_param.default
-            else:
-                pytest.skip(f"No example value for argument '{stub_param.name}'")
+            pytest.skip(f"No example value for argument '{param.name}'")
 
-        if stub_param.kind == Parameter.POSITIONAL_ONLY:
-            pos_argname_to_example_value[stub_param.name] = example_value
-        elif stub_param.kind == Parameter.POSITIONAL_OR_KEYWORD:
-            normal_argname_to_example_value[stub_param.name] = example_value
-        elif stub_param.kind == Parameter.KEYWORD_ONLY:
-            kw_argname_to_example_value[stub_param.name] = example_value
-        else:
-            pytest.skip()
+        if param.kind in VAR_KINDS:
+            pytest.skip("TODO")
+        example_values[param.kind][param.name] = example_value
 
-    if len(normal_argname_to_example_value) == 0:
-        func(*pos_argname_to_example_value.values(), **kw_argname_to_example_value)
+    if len(example_values[Parameter.POSITIONAL_OR_KEYWORD]) == 0:
+        f_func = make_pretty_func(
+            func_name,
+            example_values[Parameter.POSITIONAL_ONLY].values(),
+            example_values[Parameter.KEYWORD_ONLY],
+        )
+        note(f"trying {f_func}")
+        func(
+            *example_values[Parameter.POSITIONAL_ONLY].values(),
+            **example_values[Parameter.KEYWORD_ONLY],
+        )
     else:
-        pass  # TODO
+        either_argname_value_pairs = list(
+            example_values[Parameter.POSITIONAL_OR_KEYWORD].items()
+        )
+        n_either_args = len(either_argname_value_pairs)
+        for n_extra_args in reversed(range(n_either_args + 1)):
+            extra_args = [v for _, v in either_argname_value_pairs[:n_extra_args]]
+            if n_extra_args < n_either_args:
+                extra_kwargs = dict(either_argname_value_pairs[n_extra_args:])
+            else:
+                extra_kwargs = {}
+            args = list(example_values[Parameter.POSITIONAL_ONLY].values())
+            args += extra_args
+            kwargs = copy(example_values[Parameter.KEYWORD_ONLY])
+            if len(extra_kwargs) != 0:
+                kwargs.update(extra_kwargs)
+            f_func = make_pretty_func(func_name, args, kwargs)
+            note(f"trying {f_func}")
+            func(*args, **kwargs)
 
 
 def _test_func_signature(

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -1,16 +1,43 @@
+"""
+We're not interested in being 100% strict - instead we focus on areas which
+could affect interop, e.g. with
+
+    def add(x1, x2, /):
+        ...
+
+x1 and x2 don't need to be pos-only for the purposes of interoperability, but with
+
+    def squeeze(x, /, axis):
+        ...
+
+axis has to be pos-or-keyword to support both styles
+
+    >>> squeeze(x, 0)
+    ...
+    >>> squeeze(x, axis=0)
+    ...
+
+"""
+from collections import defaultdict
 from inspect import Parameter, Signature, signature
+from itertools import chain
 from types import FunctionType
-from typing import Callable, Dict
+from typing import Callable, DefaultDict, Dict, List
 
 import pytest
 from hypothesis import given
+from hypothesis import strategies as st
 
+from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import xps
+from ._array_module import _UndefinedStub
 from ._array_module import mod as xp
 from .stubs import array_methods, category_to_funcs, extension_to_funcs
+from .typing import DataType, Shape
 
 pytestmark = pytest.mark.ci
+
 
 kind_to_str: Dict[Parameter, str] = {
     Parameter.POSITIONAL_OR_KEYWORD: "normal argument",
@@ -20,91 +47,149 @@ kind_to_str: Dict[Parameter, str] = {
     Parameter.VAR_KEYWORD: "star-kwargs (i.e. **kwargs) argument",
 }
 
+VAR_KINDS = (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD)
 
-def _test_signature(
-    func: Callable, stub: FunctionType, ignore_first_stub_param: bool = False
-):
-    """
-    Signature of function is correct enough to not affect interoperability
 
-    We're not interested in being 100% strict - instead we focus on areas which
-    could affect interop, e.g. with
-
-        def add(x1, x2, /):
-            ...
-
-    x1 and x2 don't need to be pos-only for the purposes of interoperability, but with
-
-        def squeeze(x, /, axis):
-            ...
-
-    axis has to be pos-or-keyword to support both styles
-
-        >>> squeeze(x, 0)
-        ...
-        >>> squeeze(x, axis=0)
-        ...
-
-    """
-    try:
-        sig = signature(func)
-    except ValueError:
-        pytest.skip(
-            msg=f"type({stub.__name__})={type(func)} not supported by inspect.signature()"
-        )
+def _test_inspectable_func(sig: Signature, stub_sig: Signature):
     params = list(sig.parameters.values())
-
-    stub_sig = signature(stub)
     stub_params = list(stub_sig.parameters.values())
-    if ignore_first_stub_param:
-        stub_params = stub_params[1:]
-        stub = Signature(
-            parameters=stub_params, return_annotation=stub_sig.return_annotation
-        )
-
     # We're not interested if the array module has additional arguments, so we
     # only iterate through the arguments listed in the spec.
     for i, stub_param in enumerate(stub_params):
-        assert (
-            len(params) >= i + 1
-        ), f"Argument '{stub_param.name}' missing from signature"
-        param = params[i]
+        if sig is not None:
+            assert (
+                len(params) >= i + 1
+            ), f"Argument '{stub_param.name}' missing from signature"
+            param = params[i]
 
         # We're not interested in the name if it isn't actually used
-        if stub_param.kind not in [
+        if sig is not None and stub_param.kind not in [
             Parameter.POSITIONAL_ONLY,
-            Parameter.VAR_POSITIONAL,
-            Parameter.VAR_KEYWORD,
+            *VAR_KINDS,
         ]:
             assert (
                 param.name == stub_param.name
             ), f"Expected argument '{param.name}' to be named '{stub_param.name}'"
 
-        if (
-            stub_param.name in ["x", "x1", "x2"]
-            and stub_param.kind != Parameter.POSITIONAL_ONLY
-        ):
-            pytest.skip(
-                f"faulty spec - argument {stub_param.name} should be a "
-                f"{kind_to_str[Parameter.POSITIONAL_ONLY]}"
-            )
-        f_kind = kind_to_str[param.kind]
         f_stub_kind = kind_to_str[stub_param.kind]
-        if stub_param.kind in [
-            Parameter.POSITIONAL_OR_KEYWORD,
-            Parameter.VAR_POSITIONAL,
-            Parameter.VAR_KEYWORD,
-        ]:
-            assert (
-                param.kind == stub_param.kind
-            ), f"{param.name} is a {f_kind}, but should be a {f_stub_kind}"
+        if stub_param.kind in [Parameter.POSITIONAL_OR_KEYWORD, *VAR_KINDS]:
+            if sig is not None:
+                assert param.kind == stub_param.kind, (
+                    f"{param.name} is a {kind_to_str[param.kind]}, "
+                    f"but should be a {f_stub_kind}"
+                )
+            else:
+                pass
         else:
             # TODO: allow for kw-only args to be out-of-order
-            assert param.kind in [stub_param.kind, Parameter.POSITIONAL_OR_KEYWORD], (
-                f"{param.name} is a {f_kind}, "
-                f"but should be a {f_stub_kind} "
-                f"(or at least a {kind_to_str[Parameter.POSITIONAL_OR_KEYWORD]})"
+            if sig is not None:
+                assert param.kind in [
+                    stub_param.kind,
+                    Parameter.POSITIONAL_OR_KEYWORD,
+                ], (
+                    f"{param.name} is a {kind_to_str[param.kind]}, "
+                    f"but should be a {f_stub_kind} "
+                    f"(or at least a {kind_to_str[Parameter.POSITIONAL_OR_KEYWORD]})"
+                )
+            else:
+                pass
+
+def shapes(**kw) -> st.SearchStrategy[Shape]:
+    if "min_side" not in kw.keys():
+        kw["min_side"] = 1
+    return hh.shapes(**kw)
+
+
+matrixy_funcs: List[str] = [
+    f.__name__
+    for f in chain(category_to_funcs["linear_algebra"], extension_to_funcs["linalg"])
+]
+matrixy_funcs += ["__matmul__", "triu", "tril"]
+func_to_shapes: DefaultDict[str, st.SearchStrategy[Shape]] = defaultdict(
+    shapes,
+    {
+        **{k: st.just(()) for k in ["__bool__", "__int__", "__index__", "__float__"]},
+        "sort": shapes(min_dims=1),  # for axis=-1,
+        **{k: shapes(min_dims=2) for k in matrixy_funcs},
+        # Override for some matrixy functions
+        "cross": shapes(min_side=3, max_side=3, min_dims=3, max_dims=3),
+        "outer": shapes(min_dims=1, max_dims=1),
+    },
+)
+
+
+def get_dtypes_strategy(func_name: str) -> st.SearchStrategy[DataType]:
+    if func_name in dh.func_in_dtypes.keys():
+        dtypes = dh.func_in_dtypes[func_name]
+        if hh.FILTER_UNDEFINED_DTYPES:
+            dtypes = [d for d in dtypes if not isinstance(d, _UndefinedStub)]
+        return st.sampled_from(dtypes)
+    else:
+        return xps.scalar_dtypes()
+
+
+@given(data=st.data())
+def _test_uninspectable_func(func_name: str, func: Callable, stub_sig: Signature, data):
+    if func_name in ["cholesky", "inv"]:
+        func(xp.asarray([[1.0, 0.0], [0.0, 1.0]]))
+        return
+    elif func_name == "solve":
+        func(xp.asarray([[1.0, 2.0], [3.0, 5.0]]), xp.asarray([1.0, 2.0]))
+        return
+
+    pos_argname_to_example_value = {}
+    normal_argname_to_example_value = {}
+    kw_argname_to_example_value = {}
+    for stub_param in stub_sig.parameters.values():
+        if stub_param.name in ["x", "x1"]:
+            dtypes = get_dtypes_strategy(func_name)
+            shapes = func_to_shapes[func_name]
+            example_value = data.draw(
+                xps.arrays(dtype=dtypes, shape=shapes), label=stub_param.name
             )
+        elif stub_param.name == "x2":
+            assert "x1" in pos_argname_to_example_value.keys()  # sanity check
+            x1 = pos_argname_to_example_value["x1"]
+            example_value = data.draw(
+                xps.arrays(dtype=x1.dtype, shape=x1.shape), label="x2"
+            )
+        else:
+            if stub_param.default != Parameter.empty:
+                example_value = stub_param.default
+            else:
+                pytest.skip(f"No example value for argument '{stub_param.name}'")
+
+        if stub_param.kind == Parameter.POSITIONAL_ONLY:
+            pos_argname_to_example_value[stub_param.name] = example_value
+        elif stub_param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+            normal_argname_to_example_value[stub_param.name] = example_value
+        elif stub_param.kind == Parameter.KEYWORD_ONLY:
+            kw_argname_to_example_value[stub_param.name] = example_value
+        else:
+            pytest.skip()
+
+    if len(normal_argname_to_example_value) == 0:
+        func(*pos_argname_to_example_value.values(), **kw_argname_to_example_value)
+    else:
+        pass  # TODO
+
+
+def _test_func_signature(
+    func: Callable, stub: FunctionType, ignore_first_stub_param: bool = False
+):
+    stub_sig = signature(stub)
+    if ignore_first_stub_param:
+        stub_params = list(stub_sig.parameters.values())
+        del stub_params[0]
+        stub_sig = Signature(
+            parameters=stub_params, return_annotation=stub_sig.return_annotation
+        )
+
+    try:
+        sig = signature(func)
+        _test_inspectable_func(sig, stub_sig)
+    except ValueError:
+        _test_uninspectable_func(stub.__name__, func, stub_sig)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +200,7 @@ def _test_signature(
 def test_func_signature(stub: FunctionType):
     assert hasattr(xp, stub.__name__), f"{stub.__name__} not found in array module"
     func = getattr(xp, stub.__name__)
-    _test_signature(func, stub)
+    _test_func_signature(func, stub)
 
 
 extension_and_stub_params = []
@@ -134,13 +219,16 @@ def test_extension_func_signature(extension: str, stub: FunctionType):
         mod, stub.__name__
     ), f"{stub.__name__} not found in {extension} extension"
     func = getattr(mod, stub.__name__)
-    _test_signature(func, stub)
+    _test_func_signature(func, stub)
 
 
 @pytest.mark.parametrize("stub", array_methods, ids=lambda f: f.__name__)
-@given(x=xps.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()))
-def test_array_method_signature(stub: FunctionType, x):
+@given(data=st.data())
+def test_array_method_signature(stub: FunctionType, data):
+    dtypes = get_dtypes_strategy(stub.__name__)
+    shapes = func_to_shapes[stub.__name__]
+    x = data.draw(xps.arrays(dtype=dtypes, shape=shapes), label="x")
     assert hasattr(x, stub.__name__), f"{stub.__name__} not found in array object {x!r}"
     method = getattr(x, stub.__name__)
     # Ignore 'self' arg in stub, which won't be present in instantiated objects.
-    _test_signature(method, stub, ignore_first_stub_param=True)
+    _test_func_signature(method, stub, ignore_first_stub_param=True)

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -19,7 +19,6 @@ axis has to be pos-or-keyword to support both styles
 
 """
 from inspect import Parameter, Signature, signature
-from itertools import chain
 from types import FunctionType
 from typing import Any, Callable, Dict, List, Literal, Sequence, get_args
 
@@ -112,11 +111,11 @@ def make_pretty_func(func_name: str, args: Sequence[Any], kwargs: Dict[str, Any]
     return f_sig
 
 
-matrixy_funcs: List[str] = [
-    f.__name__
-    for f in chain(category_to_funcs["linear_algebra"], extension_to_funcs["linalg"])
+matrixy_funcs: List[FunctionType] = [
+    *category_to_funcs["linear_algebra"], *extension_to_funcs["linalg"]
 ]
-matrixy_funcs += ["__matmul__", "triu", "tril"]
+matrixy_names: List[str] = [f.__name__ for f in matrixy_funcs]
+matrixy_names += ["__matmul__", "triu", "tril"]
 
 
 @given(data=st.data())
@@ -137,7 +136,7 @@ def _test_uninspectable_func(
         "bitwise_left_shift",
         "bitwise_right_shift",
         "sort",
-        *matrixy_funcs,
+        *matrixy_names,
     ]:
         pytest.skip(skip_msg)
 


### PR DESCRIPTION
As attempted in #109, this PR revamps the signature tests so that they try using `inspect` before passing actual arguments. This wasn't done initially due to compiled funcs not being easily inspectable https://github.com/data-apis/array-api-tests/pull/109#issuecomment-1076706621, but I think it's best if we try using them as they **give us full coverage very easily when they do work... which is most of the time!**

The fallback option of passing args looks a bit different now. All arguments are inferred, and when none can be inferred we just skip the test. It turns out generating arrays somewhat naively works in a slim majority of functions, using our `dtype_helpers.py` utils to get valid dtypes. Inferred defaults from the stub signatures work most of the time too.

In cases we can't infer arguments, we skip. It seems right now only ~2/3rds of functions can get tested via the fallback option (i.e. passing args, not using `inspect`). IMO for a solution which has no hard-coded examples, that's a pretty promising start. I had played around heuristics like custom shape and element strategies for certain functions... but it kinda got messy so I thought I'd leave it to later, as it doesn't seem high priority.

Hypothesis is not strictly necessary for the fallback option, but I like writing generalised data specifications rather than hard-coded arguments—this does end up working in our favour when it comes to specifying dtypes, and shapes/elements in the future. I set `max_examples=1`when used as we don't actually care about testing edge cases here (also worth noting data draws are much faster like this compared to using `<strat>.example()`).

`test_signatures.py` is a nasty diff heh as I basically start from scratch, you'll prob just want to look at it as-is.