### PR TITLE
Implement `EqualityMapping` and use for relevant dtype helpers

### DIFF
--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -1,13 +1,11 @@
 from functools import wraps
 
 from hypothesis import strategies as st
-from hypothesis.extra.array_api import make_strategies_namespace
+from hypothesis.extra import array_api
 
 from ._array_module import mod as _xp
 
 __all__ = ["xps"]
-
-xps = make_strategies_namespace(_xp)
 
 
 # We monkey patch floats() to always disable subnormals as they are out-of-scope
@@ -23,5 +21,29 @@ def floats(*a, **kw):
 
 st.floats = floats
 
+
+# We do the same with xps.from_dtype() - this is not strictly necessary, as
+# the underlying floats() will never generate subnormals. We only do this
+# because internal logic in xps.from_dtype() assumes xp.finfo() has its
+# attributes as scalar floats, which is expected behaviour but disrupts many
+# unrelated tests.
+try:
+    __from_dtype = array_api._from_dtype
+
+    @wraps(__from_dtype)
+    def _from_dtype(*a, **kw):
+        kw["allow_subnormal"] = False
+        return __from_dtype(*a, **kw)
+
+    array_api._from_dtype = _from_dtype
+except AttributeError:
+    # Ignore monkey patching if Hypothesis changes the private API
+    pass
+
+
+xps = array_api.make_strategies_namespace(_xp)
+
+
 from . import _version
-__version__ = _version.get_versions()['version']
+
+__version__ = _version.get_versions()["version"]

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -1,4 +1,4 @@
-from collections import Mapping
+from collections.abc import Mapping
 from functools import lru_cache
 from typing import NamedTuple, Tuple, Union
 from warnings import warn

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -408,10 +408,19 @@ def fmt_types(types: Tuple[Union[DataType, ScalarType], ...]) -> str:
 
 
 class EqualityMapping(Mapping):
+    """
+    Mapping that uses equality for indexing
+
+    Typical mappings (e.g. the built-in dict) use hashing for indexing. This
+    isn't ideal for the Array API, as no __hash__() method is specified for
+    dtype objects - but __eq__() is!
+
+    See https://data-apis.org/array-api/latest/API_specification/data_types.html#data-type-objects
+    """
     def __init__(self, mapping: Mapping):
         keys = list(mapping.keys())
         for i, key in enumerate(keys):
-            if not (key == key):  # specifically test __eq__, not __neq__
+            if not (key == key):  # specifically checking __eq__, not __neq__
                 raise ValueError("Key {key!r} does not have equality with itself")
             other_keys = keys[:]
             other_keys.pop(i)
@@ -424,9 +433,14 @@ class EqualityMapping(Mapping):
         for k, v in self._mapping.items():
             if key == k:
                 return v
+        else:
+            raise KeyError(f"{key!r} not found")
 
     def __iter__(self):
         return iter(self._mapping)
 
     def __len__(self):
         return len(self._mapping)
+
+    def __repr__(self):
+        return f"EqualityMapping({self._mapping!r})"

--- a/array_api_tests/meta/test_equality_mapping.py
+++ b/array_api_tests/meta/test_equality_mapping.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ..dtype_helpers import EqualityMapping
+
+
+def test_raises_on_distinct_eq_key():
+    with pytest.raises(ValueError):
+        EqualityMapping({float("nan"): "foo"})
+
+
+def test_raises_on_indistinct_eq_keys():
+    class AlwaysEq:
+        def __init__(self, hash):
+            self._hash = hash
+
+        def __eq__(self, other):
+            return True
+
+        def __hash__(self):
+            return self._hash
+
+    with pytest.raises(ValueError):
+        EqualityMapping({AlwaysEq(0): "foo", AlwaysEq(1): "bar"})

--- a/array_api_tests/meta/test_equality_mapping.py
+++ b/array_api_tests/meta/test_equality_mapping.py
@@ -5,7 +5,7 @@ from ..dtype_helpers import EqualityMapping
 
 def test_raises_on_distinct_eq_key():
     with pytest.raises(ValueError):
-        EqualityMapping({float("nan"): "foo"})
+        EqualityMapping([(float("nan"), "value")])
 
 
 def test_raises_on_indistinct_eq_keys():
@@ -20,10 +20,18 @@ def test_raises_on_indistinct_eq_keys():
             return self._hash
 
     with pytest.raises(ValueError):
-        EqualityMapping({AlwaysEq(0): "foo", AlwaysEq(1): "bar"})
+        EqualityMapping([(AlwaysEq(0), "value1"), (AlwaysEq(1), "value2")])
 
 
 def test_key_error():
-    mapping = EqualityMapping({"foo": "bar"})
+    mapping = EqualityMapping([("key", "value")])
     with pytest.raises(KeyError):
         mapping["nonexistent key"]
+
+
+def test_iter():
+    mapping = EqualityMapping([("key", "value")])
+    it = iter(mapping)
+    assert next(it) == "key"
+    with pytest.raises(StopIteration):
+        next(it)

--- a/array_api_tests/meta/test_equality_mapping.py
+++ b/array_api_tests/meta/test_equality_mapping.py
@@ -21,3 +21,9 @@ def test_raises_on_indistinct_eq_keys():
 
     with pytest.raises(ValueError):
         EqualityMapping({AlwaysEq(0): "foo", AlwaysEq(1): "bar"})
+
+
+def test_key_error():
+    mapping = EqualityMapping({"foo": "bar"})
+    with pytest.raises(KeyError):
+        mapping["nonexistent key"]


### PR DESCRIPTION
Resolves #111 by implementing a dict-like class `EqualityMapping` that uses equality for indexing, as opposed to hashing.

The test suite would work again with NumPy-proper, except another issue now persists if you use newer versions of Hypothesis (specifically after HypothesisWorks/hypothesis#3156)—an internal check assumes floats are being returned for `xp.finfo()`, which is not the case with NumPy-proper and so an unrelated error occurs for any test using `xps.from_dtype()`... so any test using `xps.arrays()` :sweat_smile: I wrote a quick hack which now bypasses this internal check in `__init__.py`)... it's certainly not ideal, along with my original `st.floats()` monkey patching, so will mull it over.