### PR TITLE
Test special cases in statistical functions

### DIFF
--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -198,7 +198,7 @@ def assert_0d_equals(
     func_name: str, x_repr: str, x_val: Array, out_repr: str, out_val: Array, **kw
 ):
     msg = (
-        f"{out_repr}={out_val}, should be {x_repr}={x_val} "
+        f"{out_repr}={out_val}, but should be {x_repr}={x_val} "
         f"[{func_name}({fmt_kw(kw)})]"
     )
     if dh.is_float_dtype(out_val.dtype) and xp.isnan(out_val):

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -173,24 +173,6 @@ r_code = re.compile(r"``([^\s]+)``")
 r_approx_value = re.compile(
     rf"an implementation-dependent approximation to {r_code.pattern}"
 )
-
-
-def parse_inline_code(inline_code: str) -> float:
-    """
-    Parses a Sphinx code string to return a float, e.g.
-
-        >>> parse_value('``0``')
-        0.
-        >>> parse_value('``NaN``')
-        float('nan')
-
-    """
-    if m := r_code.match(inline_code):
-        return parse_value(m.group(1))
-    else:
-        raise ParseError(inline_code)
-
-
 r_not = re.compile("not (.+)")
 r_equal_to = re.compile(f"equal to {r_code.pattern}")
 r_array_element = re.compile(r"``([+-]?)x([12])_i``")

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -1339,6 +1339,28 @@ def test_iop(iop_name, iop, case, oneway_dtypes, oneway_shapes, data):
 
 
 @pytest.mark.parametrize(
+    "func_name, expected",
+    [
+        ("mean", float("nan")),
+        ("prod", 1),
+        ("std", float("nan")),
+        ("sum", 0),
+        ("var", float("nan")),
+    ],
+    ids=["mean", "prod", "std", "sum", "var"],
+)
+def test_empty_arrays(func_name, expected):  # TODO: parse docstrings to get expected
+    func = getattr(xp, func_name)
+    out = func(xp.asarray([], dtype=dh.default_float))
+    ph.assert_shape(func_name, out.shape, ())  # sanity check
+    msg = f"{out=!r}, but should be {expected}"
+    if math.isnan(expected):
+        assert xp.isnan(out), msg
+    else:
+        assert out == expected, msg
+
+
+@pytest.mark.parametrize(
     "func_name", [f.__name__ for f in category_to_funcs["statistical"]]
 )
 @given(

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -1,3 +1,14 @@
+"""
+Tests for special cases.
+
+The test cases for special casing are built on runtime via the parametrized
+test_unary and test_binary functions. Most of this file consists of utility
+classes and functions, all bought together to create the test cases (pytest
+params), to finally be run through the general test logic of either test_unary
+or test_binary.
+
+TODO: test integer arrays for relevant special cases
+"""
 # We use __future__ for forward reference type hints - this will work for even py3.8.0
 # See https://stackoverflow.com/a/33533514/5193926
 from __future__ import annotations
@@ -31,13 +42,6 @@ from .test_operators_and_elementwise_functions import (
 )
 
 pytestmark = pytest.mark.ci
-
-# The special case test casess are built on runtime via the parametrized
-# test_unary and test_binary functions. Most of this file consists of utility
-# classes and functions, all bought together to create the test cases (pytest
-# params), to finally be run through the general test logic of either test_unary
-# or test_binary.
-
 
 UnaryCheck = Callable[[float], bool]
 BinaryCheck = Callable[[float, float], bool]

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -1165,12 +1165,12 @@ for stub in category_to_funcs["elementwise"]:
         continue
     if param_names[0] == "x":
         if cases := parse_unary_docstring(stub.__doc__):
-            func_name_to_func = {stub.__name__: func}
+            name_to_func = {stub.__name__: func}
             if stub.__name__ in func_to_op.keys():
                 op_name = func_to_op[stub.__name__]
                 op = getattr(operator, op_name)
-                func_name_to_func[op_name] = op
-            for func_name, func in func_name_to_func.items():
+                name_to_func[op_name] = op
+            for func_name, func in name_to_func.items():
                 for case in cases:
                     id_ = f"{func_name}({case.cond_expr}) -> {case.result_expr}"
                     p = pytest.param(func_name, func, case, id=id_)
@@ -1181,11 +1181,11 @@ for stub in category_to_funcs["elementwise"]:
         continue
     if param_names[0] == "x1" and param_names[1] == "x2":
         if cases := parse_binary_docstring(stub.__doc__):
-            func_name_to_func = {stub.__name__: func}
+            name_to_func = {stub.__name__: func}
             if stub.__name__ in func_to_op.keys():
                 op_name = func_to_op[stub.__name__]
                 op = getattr(operator, op_name)
-                func_name_to_func[op_name] = op
+                name_to_func[op_name] = op
                 # We collect inplaceoperator test cases seperately
                 iop_name = "__i" + op_name[2:]
                 iop = getattr(operator, iop_name)
@@ -1193,7 +1193,7 @@ for stub in category_to_funcs["elementwise"]:
                     id_ = f"{iop_name}({case.cond_expr}) -> {case.result_expr}"
                     p = pytest.param(iop_name, iop, case, id=id_)
                     iop_params.append(p)
-            for func_name, func in func_name_to_func.items():
+            for func_name, func in name_to_func.items():
                 for case in cases:
                     id_ = f"{func_name}({case.cond_expr}) -> {case.result_expr}"
                     p = pytest.param(func_name, func, case, id=id_)

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -1,11 +1,10 @@
 """
 Tests for special cases.
 
-The test cases for special casing are built on runtime via the parametrized
-test_unary and test_binary functions. Most of this file consists of utility
+Most test cases for special casing are built on runtime via the parametrized
+tests test_unary/test_binary/test_iop. Most of this file consists of utility
 classes and functions, all bought together to create the test cases (pytest
-params), to finally be run through the general test logic of either test_unary
-or test_binary.
+params), to finally be run through generalised test logic.
 
 TODO: test integer arrays for relevant special cases
 """
@@ -1165,7 +1164,7 @@ for stub in category_to_funcs["elementwise"]:
                     p = pytest.param(func_name, func, case, id=id_)
                     unary_params.append(p)
         else:
-            warn("TODO")
+            warn(f"Special cases found for {stub.__name__} but none were parsed")
         continue
     if len(sig.parameters) == 1:
         warn(f"{func=} has one parameter '{param_names[0]}' which is not named 'x'")
@@ -1190,7 +1189,7 @@ for stub in category_to_funcs["elementwise"]:
                     p = pytest.param(func_name, func, case, id=id_)
                     binary_params.append(p)
         else:
-            warn("TODO")
+            warn(f"Special cases found for {stub.__name__} but none were parsed")
         continue
     else:
         warn(
@@ -1199,7 +1198,7 @@ for stub in category_to_funcs["elementwise"]:
         )
 
 
-# test_unary and test_binary naively generate arrays, i.e. arrays that might not
+# test_{unary/binary/iop} naively generate arrays, i.e. arrays that might not
 # meet the condition that is being test. We then forcibly make the array meet
 # the condition by picking a random index to insert an acceptable element.
 #

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -634,7 +634,7 @@ def parse_unary_case_block(case_block: str) -> List[UnaryCase]:
         ...         an array containing the square root of each element in ``x``
         ...     '''
         ...
-        >>> case_block = r_case_block.match(sqrt.__doc__).group(1)
+        >>> case_block = r_case_block.search(sqrt.__doc__).group(1)
         >>> unary_cases = parse_unary_case_block(case_block)
         >>> for case in unary_cases:
         ...     print(repr(case))
@@ -1094,7 +1094,7 @@ def parse_binary_case_block(case_block: str) -> List[BinaryCase]:
         ...         an array containing the results
         ...     '''
         ...
-        >>> case_block = r_case_block.match(logaddexp.__doc__).group(1)
+        >>> case_block = r_case_block.search(logaddexp.__doc__).group(1)
         >>> binary_cases = parse_binary_case_block(case_block)
         >>> for case in binary_cases:
         ...     print(repr(case))


### PR DESCRIPTION
- Resolves #41
- Simplifies some parsing logic
- Updates/extends some docs/warnings
- Replaces some parsing warnings with hard sanity-checking-assertions where I thought appropriate (i.e. technically unreachable areas, so not worth the maintenance burden of warning-then-continuing logic)
- Adds support for the newly introduced "already integer-valued" case
- Bumps `array-api` submodule