### PR TITLE
Prevent string dtypes from being split into chars in pytest_helpers

### DIFF
--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -121,7 +121,7 @@ def assert_dtype(
         >>> assert_dtype('sum', x, out.dtype, default_int)
 
     """
-    in_dtypes = in_dtype if isinstance(in_dtype, Sequence) else [in_dtype]
+    in_dtypes = in_dtype if isinstance(in_dtype, Sequence) and not isinstance(in_dtype, str) else [in_dtype]
     f_in_dtypes = dh.fmt_types(tuple(in_dtypes))
     f_out_dtype = dh.dtype_to_name[out_dtype]
     if expected is None:


### PR DESCRIPTION
For some frameworks, the data type might be represented as a string, which will then be incorrectly split into characters by the pytest helper. As an example, [Ivy](https://github.com/unifyai/ivy) uses strings to represent dtypes such that a unified framework-agnostic representation can be used.