### PR TITLE
Index testing improvements

### DIFF
--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -121,7 +121,6 @@ def is_float_dtype(dtype):
     # See https://github.com/numpy/numpy/issues/18434
     if dtype is None:
         return False
-    # TODO: Return True for float dtypes that aren't part of the spec e.g. np.float16
     return dtype in float_dtypes
 
 

--- a/array_api_tests/meta/test_pytest_helpers.py
+++ b/array_api_tests/meta/test_pytest_helpers.py
@@ -13,10 +13,10 @@ def test_assert_dtype():
     ph.assert_dtype("single_bool_func", [xp.uint8], xp.bool, xp.bool)
 
 
-def test_assert_array():
-    ph.assert_array("int zeros", xp.asarray(0), xp.asarray(0))
-    ph.assert_array("pos zeros", xp.asarray(0.0), xp.asarray(0.0))
+def test_assert_array_elements():
+    ph.assert_array_elements("int zeros", xp.asarray(0), xp.asarray(0))
+    ph.assert_array_elements("pos zeros", xp.asarray(0.0), xp.asarray(0.0))
     with raises(AssertionError):
-        ph.assert_array("mixed sign zeros", xp.asarray(0.0), xp.asarray(-0.0))
+        ph.assert_array_elements("mixed sign zeros", xp.asarray(0.0), xp.asarray(-0.0))
     with raises(AssertionError):
-        ph.assert_array("mixed sign zeros", xp.asarray(-0.0), xp.asarray(0.0))
+        ph.assert_array_elements("mixed sign zeros", xp.asarray(-0.0), xp.asarray(0.0))

--- a/array_api_tests/meta/test_utils.py
+++ b/array_api_tests/meta/test_utils.py
@@ -91,6 +91,7 @@ def test_roll_ndindex(shape, shifts, axes, expected):
         ((), "x"),
         (42, "x[42]"),
         ((42,), "x[42]"),
+        ((42, 7), "x[42, 7]"),
         (slice(None, 2), "x[:2]"),
         (slice(2, None), "x[2:]"),
         (slice(0, 2), "x[0:2]"),
@@ -98,6 +99,7 @@ def test_roll_ndindex(shape, shifts, axes, expected):
         (slice(None, None, -1), "x[::-1]"),
         (slice(None, None), "x[:]"),
         (..., "x[...]"),
+        ((None, 42), "x[None, 42]"),
     ],
 )
 def test_fmt_idx(idx, expected):

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -301,7 +301,7 @@ def assert_0d_equals(
         >>> x = xp.asarray([0, 1, 2])
         >>> res = xp.asarray(x, copy=True)
         >>> res[0] = 42
-        >>> assert_0d_equals('__setitem__', 'x[0]', x[0], 'x[0]', res[0])
+        >>> assert_0d_equals('asarray', 'x[0]', x[0], 'x[0]', res[0])
 
         is equivalent to
 

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -25,7 +25,7 @@ __all__ = [
     "assert_keepdimable_shape",
     "assert_0d_equals",
     "assert_fill",
-    "assert_array",
+    "assert_array_elements",
 ]
 
 
@@ -374,28 +374,30 @@ def assert_fill(
         assert xp.all(xp.equal(out, xp.asarray(fill_value, dtype=dtype))), msg
 
 
-def assert_array(func_name: str, out: Array, expected: Array, /, **kw):
+def assert_array_elements(
+    func_name: str, out: Array, expected: Array, /, *, out_repr: str = "out", **kw
+):
     """
-    Assert array is (strictly) as expected, e.g.
+    Assert array elements are (strictly) as expected, e.g.
 
         >>> x = xp.arange(5)
         >>> out = xp.asarray(x)
-        >>> assert_array('asarray', out, x)
+        >>> assert_array_elements('asarray', out, x)
 
         is equivalent to
 
         >>> assert xp.all(out == x)
 
     """
-    assert_dtype(func_name, out.dtype, expected.dtype)
-    assert_shape(func_name, out.shape, expected.shape, **kw)
+    dh.result_type(out.dtype, expected.dtype)  # sanity check
+    assert_shape(func_name, out.shape, expected.shape, **kw)  # sanity check
     f_func = f"[{func_name}({fmt_kw(kw)})]"
     if dh.is_float_dtype(out.dtype):
         for idx in sh.ndindex(out.shape):
             at_out = out[idx]
             at_expected = expected[idx]
             msg = (
-                f"{sh.fmt_idx('out', idx)}={at_out}, should be {at_expected} "
+                f"{sh.fmt_idx(out_repr, idx)}={at_out}, should be {at_expected} "
                 f"{f_func}"
             )
             if xp.isnan(at_expected):
@@ -411,6 +413,6 @@ def assert_array(func_name: str, out: Array, expected: Array, /, **kw):
             else:
                 assert at_out == at_expected, msg
     else:
-        assert xp.all(out == expected), (
-            f"out not as expected {f_func}\n" f"{out=}\n{expected=}"
-        )
+        assert xp.all(
+            out == expected
+        ), f"{out_repr} not as expected {f_func}\n{out_repr}={out!r}\n{expected=}"

--- a/array_api_tests/shape_helpers.py
+++ b/array_api_tests/shape_helpers.py
@@ -156,6 +156,8 @@ def fmt_i(i: AtomicIndex) -> str:
         if i.step is not None:
             res += f":{i.step}"
         return res
+    elif i is None:
+        return "None"
     else:
         return "..."
 

--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -1,6 +1,6 @@
 import math
 from itertools import product
-from typing import List, get_args
+from typing import List, Union, get_args
 
 import pytest
 from hypothesis import assume, given, note
@@ -18,7 +18,9 @@ from .typing import DataType, Param, Scalar, ScalarType, Shape
 pytestmark = pytest.mark.ci
 
 
-def scalar_objects(dtype: DataType, shape: Shape) -> st.SearchStrategy[List[Scalar]]:
+def scalar_objects(
+    dtype: DataType, shape: Shape
+) -> st.SearchStrategy[Union[Scalar, List[Scalar]]]:
     """Generates scalars or nested sequences which are valid for xp.asarray()"""
     size = math.prod(shape)
     return st.lists(xps.from_dtype(dtype), min_size=size, max_size=size).map(

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -180,7 +180,7 @@ def test_arange(dtype, data):
     if dh.is_int_dtype(_dtype):
         elements = list(r)
         assume(out.size == len(elements))
-        ph.assert_array("arange", out, xp.asarray(elements, dtype=_dtype))
+        ph.assert_array_elements("arange", out, xp.asarray(elements, dtype=_dtype))
     else:
         assume(out.size == size)
         if out.size > 0:
@@ -262,7 +262,7 @@ def test_asarray_arrays(x, data):
         ph.assert_kw_dtype("asarray", dtype, out.dtype)
     ph.assert_shape("asarray", out.shape, x.shape)
     if dtype is None or dtype == x.dtype:
-        ph.assert_array("asarray", out, x, **kw)
+        ph.assert_array_elements("asarray", out, x, **kw)
     else:
         pass  # TODO
     copy = kw.get("copy", None)
@@ -452,7 +452,7 @@ def test_linspace(num, dtype, endpoint, data):
         # the first num elements when endpoint=False
         expected = xp.linspace(start, stop, num + 1, dtype=dtype, endpoint=True)
         expected = expected[:-1]
-        ph.assert_array("linspace", out, expected)
+        ph.assert_array_elements("linspace", out, expected)
 
 
 @given(dtype=xps.numeric_dtypes(), data=st.data())

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1124,7 +1124,7 @@ def test_positive(ctx, data):
 
     ph.assert_dtype(ctx.func_name, x.dtype, out.dtype)
     ph.assert_shape(ctx.func_name, out.shape, x.shape)
-    ph.assert_array(ctx.func_name, out, x)
+    ph.assert_array_elements(ctx.func_name, out, x)
 
 
 @pytest.mark.parametrize("ctx", make_binary_params("pow", dh.numeric_dtypes))

--- a/array_api_tests/typing.py
+++ b/array_api_tests/typing.py
@@ -16,6 +16,6 @@ Scalar = Union[bool, int, float]
 ScalarType = Union[Type[bool], Type[int], Type[float]]
 Array = Any
 Shape = Tuple[int, ...]
-AtomicIndex = Union[int, "ellipsis", slice]  # noqa
+AtomicIndex = Union[int, "ellipsis", slice, None]  # noqa
 Index = Union[AtomicIndex, Tuple[AtomicIndex, ...]]
 Param = Tuple


### PR DESCRIPTION

Improves `test_getitem` and `test_setitem`:

* Test 0-sided shapes.
* Factors out key normalisation.
* Factors out `axes_indices` and `out_shape` inference.

Also

* Tests all possible dtypes for `test_asarray_arrays`.
* `ph.assert_array()` -> `ph.assert_array_elements()`, not caring about dtypes
* Generally introduces more docs/comments, typing fixes, better error messages, and logic simplification.