### PR TITLE
JSON reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pytest-json-report
+.report.json

--- a/array_api_tests/stubs.py
+++ b/array_api_tests/stubs.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 __all__ = [
     "name_to_func",
     "array_methods",
+    "array_attributes",
     "category_to_funcs",
     "EXTENSIONS",
     "extension_to_funcs",

--- a/array_api_tests/stubs.py
+++ b/array_api_tests/stubs.py
@@ -34,6 +34,10 @@ array_methods = [
     f for n, f in inspect.getmembers(array, predicate=inspect.isfunction)
     if n != "__init__"  # probably exists for Sphinx
 ]
+array_attributes = [
+    n for n, f in inspect.getmembers(array, predicate=lambda x: not inspect.isfunction(x))
+    if n != "__init__"  # probably exists for Sphinx
+]
 
 category_to_funcs: Dict[str, List[FunctionType]] = {}
 for name, mod in name_to_mod.items():

--- a/array_api_tests/test_has_names.py
+++ b/array_api_tests/test_has_names.py
@@ -1,0 +1,37 @@
+"""
+This is a very basic test to see what names are defined in a library. It
+does not even require functioning hypothesis array_api support.
+"""
+
+import pytest
+
+from ._array_module import mod as xp, mod_name
+from .stubs import (array_attributes, array_methods, category_to_funcs,
+                    extension_to_funcs, EXTENSIONS)
+
+has_name_params = []
+for ext, stubs in extension_to_funcs.items():
+    for stub in stubs:
+        has_name_params.append(pytest.param(ext, stub.__name__))
+for cat, stubs in category_to_funcs.items():
+    for stub in stubs:
+        has_name_params.append(pytest.param(cat, stub.__name__))
+for meth in array_methods:
+    has_name_params.append(pytest.param('array_method', meth.__name__))
+for attr in array_attributes:
+    has_name_params.append(pytest.param('array_attribute', attr))
+
+@pytest.mark.parametrize("category, name", has_name_params)
+def test_has_names(category, name):
+    if category in EXTENSIONS:
+        ext_mod = getattr(xp, category)
+        assert hasattr(ext_mod, name), f"{mod_name} is missing the {category} extension function {name}()"
+    elif category.startswith('array_'):
+        # TODO: This would fail if ones() is missing.
+        arr = xp.ones((1, 1))
+        if category == 'array_attribute':
+            assert hasattr(arr, name), f"The {mod_name} array object is missing the attribute {name}"
+        else:
+            assert hasattr(arr, name), f"The {mod_name} array object is missing the method {name}()"
+    else:
+        assert hasattr(xp, name), f"{mod_name} is missing the {category} function {name}()"

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -32,9 +32,9 @@ from hypothesis.strategies import DataObject
 from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import xps
-from ._array_module import _UndefinedStub
-from ._array_module import mod as xp
-from .stubs import array_methods, category_to_funcs, extension_to_funcs
+from ._array_module import _UndefinedStub, mod as xp, mod_name
+from .stubs import (array_attributes, array_methods, category_to_funcs,
+                    extension_to_funcs, EXTENSIONS)
 from .typing import Array, DataType
 
 pytestmark = pytest.mark.ci
@@ -252,3 +252,32 @@ def test_array_method_signature(stub: FunctionType, data: DataObject):
     assert hasattr(x, stub.__name__), f"{stub.__name__} not found in array object {x!r}"
     method = getattr(x, stub.__name__)
     _test_func_signature(method, stub, array=x)
+
+has_name_params = []
+for ext, stubs in extension_to_funcs.items():
+    for stub in stubs:
+        has_name_params.append(pytest.param(ext, stub.__name__))
+for cat, stubs in category_to_funcs.items():
+    for stub in stubs:
+        has_name_params.append(pytest.param(cat, stub.__name__))
+for meth in array_methods:
+    has_name_params.append(pytest.param('array_method', meth.__name__))
+for attr in array_attributes:
+    has_name_params.append(pytest.param('array_attribute', attr))
+
+# This is a very basic test to see what names are defined in a library. It
+# does not even require functioning hypothesis array_api support.
+@pytest.mark.parametrize("category, name", has_name_params)
+def test_has_names(category, name):
+    if category in EXTENSIONS:
+        ext_mod = getattr(xp, category)
+        assert hasattr(ext_mod, name), f"{mod_name} is missing the {category} extension function {name}()"
+    elif category.startswith('array_'):
+        # TODO: This would fail if ones() is missing.
+        arr = xp.ones((1, 1))
+        if category == 'array_attribute':
+            assert hasattr(arr, name), f"The {mod_name} array object is missing the attribute {name}"
+        else:
+            assert hasattr(arr, name), f"The {mod_name} array object is missing the method {name}()"
+    else:
+        assert hasattr(xp, name), f"{mod_name} is missing the {category} function {name}()"

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -32,9 +32,8 @@ from hypothesis.strategies import DataObject
 from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import xps
-from ._array_module import _UndefinedStub, mod as xp, mod_name
-from .stubs import (array_attributes, array_methods, category_to_funcs,
-                    extension_to_funcs, EXTENSIONS)
+from ._array_module import _UndefinedStub, mod as xp
+from .stubs import array_methods, category_to_funcs, extension_to_funcs
 from .typing import Array, DataType
 
 pytestmark = pytest.mark.ci
@@ -252,32 +251,3 @@ def test_array_method_signature(stub: FunctionType, data: DataObject):
     assert hasattr(x, stub.__name__), f"{stub.__name__} not found in array object {x!r}"
     method = getattr(x, stub.__name__)
     _test_func_signature(method, stub, array=x)
-
-has_name_params = []
-for ext, stubs in extension_to_funcs.items():
-    for stub in stubs:
-        has_name_params.append(pytest.param(ext, stub.__name__))
-for cat, stubs in category_to_funcs.items():
-    for stub in stubs:
-        has_name_params.append(pytest.param(cat, stub.__name__))
-for meth in array_methods:
-    has_name_params.append(pytest.param('array_method', meth.__name__))
-for attr in array_attributes:
-    has_name_params.append(pytest.param('array_attribute', attr))
-
-# This is a very basic test to see what names are defined in a library. It
-# does not even require functioning hypothesis array_api support.
-@pytest.mark.parametrize("category, name", has_name_params)
-def test_has_names(category, name):
-    if category in EXTENSIONS:
-        ext_mod = getattr(xp, category)
-        assert hasattr(ext_mod, name), f"{mod_name} is missing the {category} extension function {name}()"
-    elif category.startswith('array_'):
-        # TODO: This would fail if ones() is missing.
-        arr = xp.ones((1, 1))
-        if category == 'array_attribute':
-            assert hasattr(arr, name), f"The {mod_name} array object is missing the attribute {name}"
-        else:
-            assert hasattr(arr, name), f"The {mod_name} array object is missing the method {name}()"
-    else:
-        assert hasattr(xp, name), f"{mod_name} is missing the {category} function {name}()"

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -32,7 +32,8 @@ from hypothesis.strategies import DataObject
 from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import xps
-from ._array_module import _UndefinedStub, mod as xp
+from ._array_module import _UndefinedStub
+from ._array_module import mod as xp
 from .stubs import array_methods, category_to_funcs, extension_to_funcs
 from .typing import Array, DataType
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,13 +2,14 @@ from functools import lru_cache
 from pathlib import Path
 
 from hypothesis import settings
-from pytest import mark, fixture
+from pytest import mark
 
 from array_api_tests import _array_module as xp
 from array_api_tests._array_module import _UndefinedStub
 
-settings.register_profile("xp_default", deadline=800)
+from reporting import pytest_metadata, add_api_name_to_metadata # noqa
 
+settings.register_profile("xp_default", deadline=800)
 
 def pytest_addoption(parser):
     # Hypothesis max examples
@@ -125,23 +126,3 @@ def pytest_collection_modifyitems(config, items):
             ci_mark = next((m for m in markers if m.name == "ci"), None)
             if ci_mark is None:
                 item.add_marker(mark.skip(reason="disabled via --ci"))
-
-@mark.optionalhook
-def pytest_metadata(metadata):
-    """
-    Additional metadata for --json-report.
-    """
-    metadata['array_api_tests_module'] = xp.mod_name
-
-@fixture(autouse=True)
-def add_api_name_to_metadata(request, json_metadata):
-    test_module = request.module.__name__
-    test_function = request.function.__name__
-    assert test_function.startswith('test_'), 'unexpected test function name'
-
-    if test_module == 'array_api_tests.test_has_names':
-        array_api_function_name = None
-    else:
-        array_api_function_name = test_function[len('test_'):]
-
-    json_metadata['array_api_function_name'] = array_api_function_name

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,7 @@ from pytest import mark, fixture
 from array_api_tests import _array_module as xp
 from array_api_tests._array_module import _UndefinedStub
 
-from reporting import pytest_metadata, add_api_name_to_metadata # noqa
+from reporting import pytest_metadata, add_extra_json_metadata # noqa
 
 settings.register_profile("xp_default", deadline=800)
 
@@ -128,4 +128,4 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(mark.skip(reason="disabled via --ci"))
 
     if config.getoption('--json-report'):
-        fixture(autouse=True)(add_api_name_to_metadata)
+        fixture(autouse=True)(add_extra_json_metadata)

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from hypothesis import settings
-from pytest import mark, fixture
+from pytest import mark
 
 from array_api_tests import _array_module as xp
 from array_api_tests._array_module import _UndefinedStub
@@ -126,6 +126,3 @@ def pytest_collection_modifyitems(config, items):
             ci_mark = next((m for m in markers if m.name == "ci"), None)
             if ci_mark is None:
                 item.add_marker(mark.skip(reason="disabled via --ci"))
-
-    if config.getoption('--json-report'):
-        fixture(autouse=True)(add_extra_json_metadata)

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from hypothesis import settings
-from pytest import mark
+from pytest import mark, fixture
 
 from array_api_tests import _array_module as xp
 from array_api_tests._array_module import _UndefinedStub
@@ -132,3 +132,16 @@ def pytest_metadata(metadata):
     Additional metadata for --json-report.
     """
     metadata['array_api_tests_module'] = xp.mod_name
+
+@fixture(autouse=True)
+def add_api_name_to_metadata(request, json_metadata):
+    test_module = request.module.__name__
+    test_function = request.function.__name__
+    assert test_function.startswith('test_'), 'unexpected test function name'
+
+    if test_module == 'array_api_tests.test_has_names':
+        array_api_function_name = None
+    else:
+        array_api_function_name = test_function[len('test_'):]
+
+    json_metadata['array_api_function_name'] = array_api_function_name

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from hypothesis import settings
-from pytest import mark
+from pytest import mark, fixture
 
 from array_api_tests import _array_module as xp
 from array_api_tests._array_module import _UndefinedStub
@@ -126,3 +126,6 @@ def pytest_collection_modifyitems(config, items):
             ci_mark = next((m for m in markers if m.name == "ci"), None)
             if ci_mark is None:
                 item.add_marker(mark.skip(reason="disabled via --ci"))
+
+    if config.getoption('--json-report'):
+        fixture(autouse=True)(add_api_name_to_metadata)

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,7 @@ from pytest import mark
 from array_api_tests import _array_module as xp
 from array_api_tests._array_module import _UndefinedStub
 
-from reporting import pytest_metadata, add_extra_json_metadata # noqa
+from reporting import pytest_metadata, pytest_json_modifyreport, add_extra_json_metadata # noqa
 
 settings.register_profile("xp_default", deadline=800)
 

--- a/conftest.py
+++ b/conftest.py
@@ -126,8 +126,3 @@ def pytest_collection_modifyitems(config, items):
             ci_mark = next((m for m in markers if m.name == "ci"), None)
             if ci_mark is None:
                 item.add_marker(mark.skip(reason="disabled via --ci"))
-
-    # Avoid long tracebacks for the JSON report, which make the file too
-    # large.
-    if config.getoption('--json-report'):
-        config.option.tbstyle = 'native'

--- a/conftest.py
+++ b/conftest.py
@@ -126,3 +126,8 @@ def pytest_collection_modifyitems(config, items):
             ci_mark = next((m for m in markers if m.name == "ci"), None)
             if ci_mark is None:
                 item.add_marker(mark.skip(reason="disabled via --ci"))
+
+    # Avoid long tracebacks for the JSON report, which make the file too
+    # large.
+    if config.getoption('--json-report'):
+        config.option.tbstyle = 'native'

--- a/conftest.py
+++ b/conftest.py
@@ -120,8 +120,15 @@ def pytest_collection_modifyitems(config, items):
                         mark.skip(reason="disabled via --disable-data-dependent-shapes")
                     )
                     break
-        # skip if test not appropiate for CI
+        # skip if test not appropriate for CI
         if ci:
             ci_mark = next((m for m in markers if m.name == "ci"), None)
             if ci_mark is None:
                 item.add_marker(mark.skip(reason="disabled via --ci"))
+
+@mark.optionalhook
+def pytest_metadata(metadata):
+    """
+    Additional metadata for --json-report.
+    """
+    metadata['array_api_tests_module'] = xp.mod_name

--- a/reporting.py
+++ b/reporting.py
@@ -9,6 +9,10 @@ import json
 from hypothesis.strategies import SearchStrategy
 
 from pytest import mark
+try:
+    import pytest_jsonreport # noqa
+except ImportError:
+    raise ImportError("pytest-json-report is required to run the array API tests")
 
 def to_json_serializable(o):
     if o in dtype_to_name:

--- a/reporting.py
+++ b/reporting.py
@@ -38,7 +38,8 @@ def pytest_metadata(metadata):
     metadata['array_api_tests_module'] = xp.mod_name
     metadata['array_api_tests_version'] = __version__
 
-@fixture(autouse=True)
+# This is dynamically decorated as a fixture in pytest_collection_modifyitems
+# when --json-report is used.
 def add_api_name_to_metadata(request, json_metadata):
     """
     Additional per-test metadata for --json-report

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,58 @@
+from array_api_tests.test_operators_and_elementwise_functions import (UnaryParamContext, BinaryParamContext)
+from array_api_tests.dtype_helpers import dtype_to_name
+from array_api_tests import _array_module as xp
+
+from pytest import mark, fixture
+
+def to_json_serializable(o):
+    if o in dtype_to_name:
+        return dtype_to_name[o]
+    if isinstance(o, UnaryParamContext):
+        return {'func_name': o.func_name}
+    if isinstance(o, BinaryParamContext):
+        return {
+            'func_name': o.func_name,
+            'left_sym': o.left_sym,
+            'right_sym': o.right_sym,
+            'right_is_scalar': o.right_is_scalar,
+            'res_name': o.res_name,
+        }
+    if isinstance(o, dict):
+        return {to_json_serializable(k): to_json_serializable(v) for k, v in o.items()}
+    if isinstance(o, tuple):
+        return tuple(to_json_serializable(i) for i in o)
+    if isinstance(o, list):
+        return [to_json_serializable(i) for i in o]
+
+    return o
+
+@mark.optionalhook
+def pytest_metadata(metadata):
+    """
+    Additional global metadata for --json-report.
+    """
+    metadata['array_api_tests_module'] = xp.mod_name
+
+@fixture(autouse=True)
+def add_api_name_to_metadata(request, json_metadata):
+    """
+    Additional per-test metadata for --json-report
+    """
+    test_module = request.module.__name__
+    if test_module.startswith('array_api_tests.meta'):
+        return
+
+    test_function = request.function.__name__
+    assert test_function.startswith('test_'), 'unexpected test function name'
+
+    if test_module == 'array_api_tests.test_has_names':
+        array_api_function_name = None
+    else:
+        array_api_function_name = test_function[len('test_'):]
+
+    json_metadata['test_module'] = test_module
+    json_metadata['test_function'] = test_function
+    json_metadata['array_api_function_name'] = array_api_function_name
+
+    if hasattr(request.node, 'callspec'):
+        json_metadata['params'] = to_json_serializable(request.node.callspec.params)

--- a/reporting.py
+++ b/reporting.py
@@ -40,7 +40,7 @@ def pytest_metadata(metadata):
 
 # This is dynamically decorated as a fixture in pytest_collection_modifyitems
 # when --json-report is used.
-def add_api_name_to_metadata(request, json_metadata):
+def add_extra_json_metadata(request, json_metadata):
     """
     Additional per-test metadata for --json-report
     """

--- a/reporting.py
+++ b/reporting.py
@@ -1,5 +1,6 @@
 from array_api_tests.dtype_helpers import dtype_to_name
 from array_api_tests import _array_module as xp
+from array_api_tests import __version__
 
 from types import BuiltinFunctionType, FunctionType
 import dataclasses
@@ -34,6 +35,7 @@ def pytest_metadata(metadata):
     Additional global metadata for --json-report.
     """
     metadata['array_api_tests_module'] = xp.mod_name
+    metadata['array_api_tests_version'] = __version__
 
 @fixture(autouse=True)
 def add_api_name_to_metadata(request, json_metadata):

--- a/reporting.py
+++ b/reporting.py
@@ -8,7 +8,7 @@ import json
 
 from hypothesis.strategies import SearchStrategy
 
-from pytest import mark, fixture
+from pytest import mark
 
 def to_json_serializable(o):
     if o in dtype_to_name:

--- a/reporting.py
+++ b/reporting.py
@@ -13,7 +13,7 @@ from pytest import mark
 def to_json_serializable(o):
     if o in dtype_to_name:
         return dtype_to_name[o]
-    if isinstance(o, (BuiltinFunctionType, FunctionType)):
+    if isinstance(o, (BuiltinFunctionType, FunctionType, type)):
         return o.__name__
     if dataclasses.is_dataclass(o):
         return to_json_serializable(dataclasses.asdict(o))

--- a/reporting.py
+++ b/reporting.py
@@ -8,7 +8,7 @@ import json
 
 from hypothesis.strategies import SearchStrategy
 
-from pytest import mark
+from pytest import mark, fixture
 try:
     import pytest_jsonreport # noqa
 except ImportError:
@@ -42,8 +42,7 @@ def pytest_metadata(metadata):
     metadata['array_api_tests_module'] = xp.mod_name
     metadata['array_api_tests_version'] = __version__
 
-# This is dynamically decorated as a fixture in pytest_collection_modifyitems
-# when --json-report is used.
+@fixture(autouse=True)
 def add_extra_json_metadata(request, json_metadata):
     """
     Additional per-test metadata for --json-report

--- a/reporting.py
+++ b/reporting.py
@@ -61,3 +61,13 @@ def add_api_name_to_metadata(request, json_metadata):
     if hasattr(request.node, 'callspec'):
         params = request.node.callspec.params
         json_metadata['params'] = to_json_serializable(params)
+
+    def finalizer():
+        # TODO: This metadata is all in the form of error strings. It might be
+        # nice to extract the hypothesis failing inputs directly somehow.
+        if hasattr(request.node, 'hypothesis_report_information'):
+            json_metadata['hypothesis_report_information'] = request.node.hypothesis_report_information
+        if hasattr(request.node, 'hypothesis_statistics'):
+            json_metadata['hypothesis_statistics'] = request.node.hypothesis_statistics
+
+    request.addfinalizer(finalizer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
+pytest-json-report
 hypothesis>=6.45.0
 ndindex>=1.6


### PR DESCRIPTION
JSON reporting will be done with the [pytest-json-report package](https://pypi.org/project/pytest-json-report/). This produces a pretty usable JSON and makes it easy to extend it with custom metadata at test run time.

The idea will be to take the JSON generated by pytest-json-report and translate it into something more usable by a reporting tool. To start with, I will focus on test_has_names, which has been reintroduced here, to list which spec names are or are not defined in the given package.