### PR TITLE
Bump Hypothesis, specify `api_version` in `make_strategies_namespace()`

### DIFF
--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -41,7 +41,7 @@ except AttributeError:
     pass
 
 
-xps = array_api.make_strategies_namespace(_xp)
+xps = array_api.make_strategies_namespace(_xp, api_version="2021.12")
 
 
 from . import _version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-json-report
-hypothesis>=6.45.0
+hypothesis>=6.55.0
 ndindex>=1.6


### PR DESCRIPTION
This PR prevents Hypothesis from inferring versions by just specifying `2021.12`, given the test suite still only assumes `2021.12` features. This is a temporary solution to work with a recent Hypothesis update, hopefully to prevent issues like https://github.com/cupy/cupy/pull/7072. Next step is to support testing different versions (#20), where instead of hardcoding this, we can allow specification via an env variable.