### PR TITLE
Fix array_attributes

### DIFF
--- a/array_api_tests/stubs.py
+++ b/array_api_tests/stubs.py
@@ -36,8 +36,7 @@ array_methods = [
     if n != "__init__"  # probably exists for Sphinx
 ]
 array_attributes = [
-    n for n, f in inspect.getmembers(array, predicate=lambda x: not inspect.isfunction(x))
-    if n != "__init__"  # probably exists for Sphinx
+    n for n, f in inspect.getmembers(array, predicate=lambda x: isinstance(x, property))
 ]
 
 category_to_funcs: Dict[str, List[FunctionType]] = {}


### PR DESCRIPTION
Previously it was including every method inherited from object, like __dict__. Now it only includes the properties actually defined on the array stub class.