### PR TITLE
Fix undefined dtypes being passed in kwargs of stat tests

### DIFF
--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -20,6 +20,8 @@ pytestmark = pytest.mark.ci
 
 def kwarg_dtypes(dtype: DataType) -> st.SearchStrategy[Optional[DataType]]:
     dtypes = [d2 for d1, d2 in dh.promotion_table if d1 == dtype]
+    if hh.FILTER_UNDEFINED_DTYPES:
+        dtypes = [d for d in dtypes if not isinstance(d, _UndefinedStub)]
     return st.none() | st.sampled_from(dtypes)
 
 


### PR DESCRIPTION
@asmeurer noted undefined dtypes could be passed as the dtype kwarg for `test_prod`, i.e. for pytorch (using https://github.com/data-apis/array-api-compat/pull/14).

```python
$ ARRAY_API_TESTS_MODULE=array_api_compat.torch pytest --disable-warnings array_api_tests/test_statistical_functions.py::test_prod
...
TypeError: prod() received an invalid combination of arguments - got (Tensor, dtype=_UndefinedStub), but expected one of:
Falsifying example: test_prod(
    x=tensor(0, dtype=torch.uint8), data=data(...),
)
Draw 1 (kw): {'dtype': <undefined stub for 'uint32'>
```

This PR filters the pool of available dtypes so this doesn't happen for either `test_prod` or `test_sum`. Note these tests will still fail for pytorch as it doesn't follow the prod/sum-specific type promotion rules of the Array API.