### PR TITLE
Bump Hypothesis to `6.21.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-json-report
-hypothesis>=6.55.0
+hypothesis>=6.62.1
 ndindex>=1.6


### PR DESCRIPTION
Resolves #159, as Hypothesis now doesn't pass int-shapes to `xp.full()`, which doesn't work with PyTorch.

Some other issues with the signature tests now, will explore.