### PR TITLE
Versioning support, bulk of complex testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ library to fail.
 #### API version
 
 You can specify the API version to use when testing via the
-ARRAY_API_TESTS_VERSION environment variable. Currently this defaults to
-`"2021.12"`.
+`ARRAY_API_TESTS_VERSION` environment variable. Currently this defaults to the
+array module's `__array_api_version__` value, and if that attribute doesn't
+exist then we fallback to `"2021.12"`.
 
 #### CI flag
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ library to fail.
 
 ### Configuration
 
+#### API version
+
+You can specify the API version to use when testing via the
+ARRAY_API_TESTS_VERSION environment variable. Currently this defaults to
+`"2021.12"`.
+
 #### CI flag
 
 Use the `--ci` flag to run only the primary and special cases tests. You can

--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -1,11 +1,16 @@
 from functools import wraps
+from os import getenv
 
 from hypothesis import strategies as st
 from hypothesis.extra import array_api
 
+from . import _version
 from ._array_module import mod as _xp
 
-__all__ = ["xps"]
+__all__ = ["COMPLEX_VER", "api_version", "xps"]
+
+
+COMPLEX_VER: str = "2022.12"
 
 
 # We monkey patch floats() to always disable subnormals as they are out-of-scope
@@ -41,9 +46,7 @@ except AttributeError:
     pass
 
 
-xps = array_api.make_strategies_namespace(_xp, api_version="2021.12")
-
-
-from . import _version
+api_version = getenv("ARRAY_API_TESTS_VERSION", "2021.12")
+xps = array_api.make_strategies_namespace(_xp, api_version=api_version)
 
 __version__ = _version.get_versions()["version"]

--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -46,7 +46,9 @@ except AttributeError:
     pass
 
 
-api_version = getenv("ARRAY_API_TESTS_VERSION", "2021.12")
+api_version = getenv(
+    "ARRAY_API_TESTS_VERSION", getattr(_xp, "__array_api_version__", "2021.12")
+)
 xps = array_api.make_strategies_namespace(_xp, api_version=api_version)
 
 __version__ = _version.get_versions()["version"]

--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -7,10 +7,7 @@ from hypothesis.extra import array_api
 from . import _version
 from ._array_module import mod as _xp
 
-__all__ = ["COMPLEX_VER", "api_version", "xps"]
-
-
-COMPLEX_VER: str = "2022.12"
+__all__ = ["api_version", "xps"]
 
 
 # We monkey patch floats() to always disable subnormals as they are out-of-scope

--- a/array_api_tests/_array_module.py
+++ b/array_api_tests/_array_module.py
@@ -58,6 +58,7 @@ _dtypes = [
     "uint8", "uint16", "uint32", "uint64",
     "int8", "int16", "int32", "int64",
     "float32", "float64",
+    "complex64", "complex128",
 ]
 _constants = ["e", "inf", "nan", "pi"]
 _funcs = [f.__name__ for funcs in stubs.category_to_funcs.values() for f in funcs]

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -5,6 +5,7 @@ from inspect import signature
 from typing import Any, Dict, NamedTuple, Sequence, Tuple, Union
 from warnings import warn
 
+from . import api_version
 from . import _array_module as xp
 from ._array_module import _UndefinedStub
 from .stubs import name_to_func
@@ -29,6 +30,7 @@ __all__ = [
     "default_int",
     "default_uint",
     "default_float",
+    "default_complex",
     "promotion_table",
     "dtype_nbits",
     "dtype_signed",
@@ -197,6 +199,15 @@ else:
     default_float = xp.asarray(float()).dtype
     if default_float not in float_dtypes:
         warn(f"inferred default float is {default_float!r}, which is not a float")
+    if api_version > "2021.12":
+        default_complex = xp.asarray(complex()).dtype
+        if default_complex not in complex_dtypes:
+            warn(
+                f"inferred default complex is {default_complex!r}, "
+                "which is not a complex"
+            )
+    else:
+        default_complex = None
 if dtype_nbits[default_int] == 32:
     default_uint = xp.uint32
 else:

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -18,8 +18,9 @@ __all__ = [
     "real_dtypes",
     "numeric_dtypes",
     "all_dtypes",
-    "dtype_to_name",
+    "all_float_dtypes",
     "bool_and_all_int_dtypes",
+    "dtype_to_name",
     "dtype_to_scalars",
     "is_int_dtype",
     "is_float_dtype",
@@ -102,6 +103,7 @@ real_dtypes = all_int_dtypes + float_dtypes
 complex_dtypes = tuple(getattr(xp, name) for name in _complex_names)
 numeric_dtypes = real_dtypes + complex_dtypes
 all_dtypes = (xp.bool,) + numeric_dtypes
+all_float_dtypes = float_dtypes + complex_dtypes
 bool_and_all_int_dtypes = (xp.bool,) + all_int_dtypes
 
 

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -103,9 +103,13 @@ float_dtypes = tuple(getattr(xp, name) for name in _float_names)
 all_int_dtypes = uint_dtypes + int_dtypes
 real_dtypes = all_int_dtypes + float_dtypes
 complex_dtypes = tuple(getattr(xp, name) for name in _complex_names)
-numeric_dtypes = real_dtypes + complex_dtypes
+numeric_dtypes = real_dtypes
+if api_version > "2021.12":
+    numeric_dtypes += complex_dtypes
 all_dtypes = (xp.bool,) + numeric_dtypes
-all_float_dtypes = float_dtypes + complex_dtypes
+all_float_dtypes = float_dtypes
+if api_version > "2021.12":
+    all_float_dtypes += complex_dtypes
 bool_and_all_int_dtypes = (xp.bool,) + all_int_dtypes
 
 
@@ -132,7 +136,10 @@ def is_float_dtype(dtype):
     # See https://github.com/numpy/numpy/issues/18434
     if dtype is None:
         return False
-    return dtype in float_dtypes
+    valid_dtypes = float_dtypes
+    if api_version > "2021.12":
+        valid_dtypes += complex_dtypes
+    return dtype in valid_dtypes
 
 
 def get_scalar_type(dtype: DataType) -> ScalarType:

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -46,7 +46,7 @@ if FILTER_UNDEFINED_DTYPES:
 shared_dtypes = shared(dtypes, key="dtype")
 shared_floating_dtypes = shared(floating_dtypes, key="dtype")
 
-_dtype_categories = [(xp.bool,), dh.uint_dtypes, dh.int_dtypes, dh.float_dtypes]
+_dtype_categories = [(xp.bool,), dh.uint_dtypes, dh.int_dtypes, dh.float_dtypes, dh.complex_dtypes]
 _sorted_dtypes = [d for category in _dtype_categories for d in category]
 
 def _dtypes_sorter(dtype_pair: Tuple[DataType, DataType]):

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -26,22 +26,15 @@ from .typing import Array, DataType, Shape
 # work for floating point dtypes as those are assumed to be defined in other
 # places in the tests.
 FILTER_UNDEFINED_DTYPES = True
+# TODO: currently we assume this to be true - we probably can remove this completely
+assert FILTER_UNDEFINED_DTYPES
 
-integer_dtypes = sampled_from(dh.all_int_dtypes)
-floating_dtypes = sampled_from(dh.float_dtypes)
-numeric_dtypes = sampled_from(dh.numeric_dtypes)
-integer_or_boolean_dtypes = sampled_from(dh.bool_and_all_int_dtypes)
-boolean_dtypes = just(xp.bool)
-dtypes = sampled_from(dh.all_dtypes)
-
-if FILTER_UNDEFINED_DTYPES:
-    integer_dtypes = integer_dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
-    floating_dtypes = floating_dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
-    numeric_dtypes = numeric_dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
-    integer_or_boolean_dtypes = integer_or_boolean_dtypes.filter(lambda x: not
-                                                                 isinstance(x, _UndefinedStub))
-    boolean_dtypes = boolean_dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
-    dtypes = dtypes.filter(lambda x: not isinstance(x, _UndefinedStub))
+integer_dtypes = xps.integer_dtypes() | xps.unsigned_integer_dtypes()
+floating_dtypes = xps.floating_dtypes()
+numeric_dtypes = xps.numeric_dtypes()
+integer_or_boolean_dtypes = xps.boolean_dtypes() | integer_dtypes
+boolean_dtypes = xps.boolean_dtypes()
+dtypes = xps.scalar_dtypes()
 
 shared_dtypes = shared(dtypes, key="dtype")
 shared_floating_dtypes = shared(floating_dtypes, key="dtype")

--- a/array_api_tests/meta/test_utils.py
+++ b/array_api_tests/meta/test_utils.py
@@ -4,15 +4,12 @@ from hypothesis import strategies as st
 
 from .. import _array_module as xp
 from .. import dtype_helpers as dh
+from .. import hypothesis_helpers as hh
 from .. import shape_helpers as sh
 from .. import xps
 from ..test_creation_functions import frange
 from ..test_manipulation_functions import roll_ndindex
-from ..test_operators_and_elementwise_functions import (
-    mock_int_dtype,
-    oneway_broadcastable_shapes,
-    oneway_promotable_dtypes,
-)
+from ..test_operators_and_elementwise_functions import mock_int_dtype
 
 
 @pytest.mark.parametrize(
@@ -115,11 +112,11 @@ def test_int_to_dtype(x, dtype):
     assert mock_int_dtype(x, dtype) == d
 
 
-@given(oneway_promotable_dtypes(dh.all_dtypes))
+@given(hh.oneway_promotable_dtypes(dh.all_dtypes))
 def test_oneway_promotable_dtypes(D):
     assert D.result_dtype == dh.result_type(*D)
 
 
-@given(oneway_broadcastable_shapes())
+@given(hh.oneway_broadcastable_shapes())
 def test_oneway_broadcastable_shapes(S):
     assert S.result_shape == sh.broadcast_shapes(*S)

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -170,6 +170,23 @@ def assert_default_float(func_name: str, out_dtype: DataType):
     assert out_dtype == dh.default_float, msg
 
 
+def assert_default_complex(func_name: str, out_dtype: DataType):
+    """
+    Assert the output dtype is the default complex, e.g.
+
+        >>> out = xp.asarray(4+2j)
+        >>> assert_default_complex('asarray', out.dtype)
+
+    """
+    f_dtype = dh.dtype_to_name[out_dtype]
+    f_default = dh.dtype_to_name[dh.default_complex]
+    msg = (
+        f"out.dtype={f_dtype}, should be default "
+        f"complex dtype {f_default} [{func_name}()]"
+    )
+    assert out_dtype == dh.default_complex, msg
+
+
 def assert_default_int(func_name: str, out_dtype: DataType):
     """
     Assert the output dtype is the default int, e.g.

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -1,3 +1,4 @@
+import cmath
 import math
 from inspect import getfullargspec
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
@@ -345,12 +346,12 @@ def assert_scalar_equals(
     if type_ in [bool, int]:
         msg = f"{repr_name}={out}, but should be {expected} [{f_func}]"
         assert out == expected, msg
-    elif math.isnan(expected):
+    elif cmath.isnan(expected):
         msg = f"{repr_name}={out}, but should be {expected} [{f_func}]"
-        assert math.isnan(out), msg
+        assert cmath.isnan(out), msg
     else:
         msg = f"{repr_name}={out}, but should be roughly {expected} [{f_func}]"
-        assert math.isclose(out, expected, rel_tol=0.25, abs_tol=1), msg
+        assert cmath.isclose(out, expected, rel_tol=0.25, abs_tol=1), msg
 
 
 def assert_fill(
@@ -368,7 +369,7 @@ def assert_fill(
 
     """
     msg = f"out not filled with {fill_value} [{func_name}({fmt_kw(kw)})]\n{out=}"
-    if math.isnan(fill_value):
+    if cmath.isnan(fill_value):
         assert xp.all(xp.isnan(out)), msg
     else:
         assert xp.all(xp.equal(out, xp.asarray(fill_value, dtype=dtype))), msg

--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -1,3 +1,4 @@
+import cmath
 import math
 from itertools import product
 from typing import List, Sequence, Tuple, Union, get_args
@@ -135,7 +136,7 @@ def test_setitem(shape, dtypes, data):
     f_res = sh.fmt_idx("x", key)
     if isinstance(value, get_args(Scalar)):
         msg = f"{f_res}={res[key]!r}, but should be {value=} [__setitem__()]"
-        if math.isnan(value):
+        if cmath.isnan(value):
             assert xp.isnan(res[key]), msg
         else:
             assert res[key] == value, msg

--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -12,7 +12,6 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
-from .test_operators_and_elementwise_functions import oneway_promotable_dtypes
 from .typing import DataType, Index, Param, Scalar, ScalarType, Shape
 
 pytestmark = pytest.mark.ci
@@ -108,7 +107,7 @@ def test_getitem(shape, dtype, data):
 
 @given(
     shape=hh.shapes(),
-    dtypes=oneway_promotable_dtypes(dh.all_dtypes),
+    dtypes=hh.oneway_promotable_dtypes(dh.all_dtypes),
     data=st.data(),
 )
 def test_setitem(shape, dtypes, data):

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -12,7 +12,6 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
-from .test_operators_and_elementwise_functions import oneway_promotable_dtypes
 from .typing import DataType, Scalar
 
 pytestmark = pytest.mark.ci
@@ -256,7 +255,7 @@ def scalar_eq(s1: Scalar, s2: Scalar) -> bool:
 
 @given(
     shape=hh.shapes(),
-    dtypes=oneway_promotable_dtypes(dh.all_dtypes),
+    dtypes=hh.oneway_promotable_dtypes(dh.all_dtypes),
     data=st.data(),
 )
 def test_asarray_arrays(shape, dtypes, data):

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -1,3 +1,4 @@
+import cmath
 import math
 from itertools import count
 from typing import Iterator, NamedTuple, Union
@@ -247,8 +248,8 @@ def test_asarray_scalars(shape, data):
 
 
 def scalar_eq(s1: Scalar, s2: Scalar) -> bool:
-    if math.isnan(s1):
-        return math.isnan(s2)
+    if cmath.isnan(s1):
+        return cmath.isnan(s2)
     else:
         return s1 == s2
 

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -79,7 +79,8 @@ def reals(min_value=None, max_value=None) -> st.SearchStrategy[Union[int, float]
     )
 
 
-@given(dtype=st.none() | hh.numeric_dtypes, data=st.data())
+# TODO: support testing complex dtypes
+@given(dtype=st.none() | xps.real_dtypes(), data=st.data())
 def test_arange(dtype, data):
     if dtype is None or dh.is_float_dtype(dtype):
         start = data.draw(reals(), label="start")
@@ -128,6 +129,12 @@ def test_arange(dtype, data):
         assert m <= _start <= M
         assert m <= _stop <= M
         assert m <= step <= M
+        # Ignore ridiculous distances so we don't fail like
+        #
+        #     >>> torch.arange(9132051521638391890, 0, -91320515216383920)
+        #     RuntimeError: invalid size, possible overflow?
+        #
+        assume(abs(_start - _stop) < M // 2)
 
     r = frange(_start, _stop, step)
     size = len(r)

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -470,7 +470,7 @@ def test_linspace(num, dtype, endpoint, data):
     assume(not xp.isnan(xp.asarray(start - stop, dtype=_dtype)))
     # avoid generating very large distances
     # https://github.com/data-apis/array-api-tests/issues/125
-    assume(abs(stop - start) < dh.dtype_ranges[_dtype].max)
+    assume(abs(stop - start) < math.sqrt(dh.dtype_ranges[_dtype].max))
 
     kw = data.draw(
         hh.specified_kwargs(

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -315,7 +315,7 @@ def test_asarray_arrays(shape, dtypes, data):
             ), f"{f_out}, but should be {value} after x was mutated"
 
 
-@given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.shared_dtypes))
+@given(hh.shapes(), hh.kwargs(dtype=st.none() | xps.scalar_dtypes()))
 def test_empty(shape, kw):
     out = xp.empty(shape, **kw)
     if kw.get("dtype", None) is None:

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -12,6 +12,7 @@ functions from the linalg extension. The functions in the latter are not
 required, but we don't yet have a clean way to disable only those tests (see https://github.com/data-apis/array-api-tests/issues/25).
 
 """
+# TODO: test with complex dtypes where appropiate
 
 import pytest
 from hypothesis import assume, given
@@ -20,7 +21,7 @@ from hypothesis.strategies import (booleans, composite, none, tuples, integers,
 from ndindex import iter_indices
 
 from .array_helpers import assert_exactly_equal, asarray
-from .hypothesis_helpers import (xps, dtypes, shapes, kwargs, matrix_shapes,
+from .hypothesis_helpers import (xps, shapes, kwargs, matrix_shapes,
                                  square_matrix_shapes, symmetric_matrices,
                                  positive_definite_matrices, MAX_ARRAY_SIZE,
                                  invertible_matrices, two_mutual_arrays,
@@ -117,7 +118,7 @@ def test_cholesky(x, kw):
 
 
 @composite
-def cross_args(draw, dtype_objects=dh.numeric_dtypes):
+def cross_args(draw, dtype_objects=dh.real_dtypes):
     """
     cross() requires two arrays with a size 3 in the 'axis' dimension
 
@@ -192,7 +193,7 @@ def test_det(x):
 
 @pytest.mark.xp_extension('linalg')
 @given(
-    x=xps.arrays(dtype=dtypes, shape=matrix_shapes()),
+    x=xps.arrays(dtype=xps.real_dtypes(), shape=matrix_shapes()),
     # offset may produce an overflow if it is too large. Supporting offsets
     # that are way larger than the array shape isn't very important.
     kw=kwargs(offset=integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE))
@@ -277,7 +278,7 @@ def test_inv(x):
     # TODO: Test that the result is actually the inverse
 
 @given(
-    *two_mutual_arrays(dh.numeric_dtypes)
+    *two_mutual_arrays(dh.real_dtypes)
 )
 def test_matmul(x1, x2):
     # TODO: Make this also test the @ operator
@@ -366,7 +367,7 @@ def test_matrix_rank(x, kw):
     linalg.matrix_rank(x, **kw)
 
 @given(
-    x=xps.arrays(dtype=dtypes, shape=matrix_shapes()),
+    x=xps.arrays(dtype=xps.real_dtypes(), shape=matrix_shapes()),
 )
 def test_matrix_transpose(x):
     res = _array_module.matrix_transpose(x)
@@ -384,7 +385,7 @@ def test_matrix_transpose(x):
 
 @pytest.mark.xp_extension('linalg')
 @given(
-    *two_mutual_arrays(dtypes=dh.numeric_dtypes,
+    *two_mutual_arrays(dtypes=dh.real_dtypes,
                        two_shapes=tuples(one_d_shapes, one_d_shapes))
 )
 def test_outer(x1, x2):
@@ -573,7 +574,7 @@ def test_svdvals(x):
 
 
 @given(
-    dtypes=mutually_promotable_dtypes(dtypes=dh.numeric_dtypes),
+    dtypes=mutually_promotable_dtypes(dtypes=dh.real_dtypes),
     shape=shapes(),
     data=data(),
 )
@@ -590,7 +591,7 @@ def test_tensordot(dtypes, shape, data):
 
 @pytest.mark.xp_extension('linalg')
 @given(
-    x=xps.arrays(dtype=xps.numeric_dtypes(), shape=matrix_shapes()),
+    x=xps.arrays(dtype=xps.real_dtypes(), shape=matrix_shapes()),
     # offset may produce an overflow if it is too large. Supporting offsets
     # that are way larger than the array shape isn't very important.
     kw=kwargs(offset=integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE))
@@ -629,7 +630,7 @@ def test_trace(x, kw):
 
 
 @given(
-    dtypes=mutually_promotable_dtypes(dtypes=dh.numeric_dtypes),
+    dtypes=mutually_promotable_dtypes(dtypes=dh.real_dtypes),
     shape=shapes(min_dims=1),
     data=data(),
 )

--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -350,7 +350,6 @@ def test_stack(shape, dtypes, kw, data):
     out_indices = sh.ndindex(out.shape)
     for idx in sh.axis_ndindex(arrays[0].shape, axis=_axis):
         f_idx = ", ".join(str(i) if isinstance(i, int) else ":" for i in idx)
-        print(f"{f_idx=}")
         for x_num, x in enumerate(arrays, 1):
             indexed_x = x[idx]
             for x_idx in sh.ndindex(indexed_x.shape):

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -959,12 +959,14 @@ def test_divide(ctx, data):
     left = data.draw(ctx.left_strat, label=ctx.left_sym)
     right = data.draw(ctx.right_strat, label=ctx.right_sym)
     if ctx.right_is_scalar:
-        assume
+        assume  # TODO: assume what?
 
     res = ctx.func(left, right)
 
     binary_param_assert_dtype(ctx, left, right, res)
     binary_param_assert_shape(ctx, left, right, res)
+    if res.dtype in dh.complex_dtypes:
+        return  # TOOD: handle complex division
     binary_param_assert_against_refimpl(
         ctx,
         left,

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -3,6 +3,7 @@ Test element-wise functions/operators against reference implementations.
 """
 import math
 import operator
+from copy import copy
 from enum import Enum, auto
 from typing import Callable, List, NamedTuple, Optional, Sequence, TypeVar, Union
 
@@ -103,8 +104,6 @@ def default_filter(s: Scalar) -> bool:
     """
     if isinstance(s, int):  # note bools are ints
         return True
-    elif isinstance(s, complex):
-        return default_filter(s.real) and default_filter(s.imag)
     else:
         return math.isfinite(s) and s != 0
 
@@ -255,6 +254,9 @@ def unary_assert_against_refimpl(
         m, M = dh.dtype_ranges[dh.dtype_components[res.dtype]]
     else:
         m, M = dh.dtype_ranges[res.dtype]
+    if in_.dtype in dh.complex_dtypes:
+        component_filter = copy(filter_)
+        filter_ = lambda s: component_filter(s.real) and component_filter(s.imag)
     for idx in sh.ndindex(in_.shape):
         scalar_i = in_stype(in_[idx])
         if not filter_(scalar_i):
@@ -313,6 +315,9 @@ def binary_assert_against_refimpl(
     if res_stype is None:
         res_stype = in_stype
     m, M = dh.dtype_ranges.get(res.dtype, (None, None))
+    if left.dtype in dh.complex_dtypes:
+        component_filter = copy(filter_)
+        filter_ = lambda s: component_filter(s.real) and component_filter(s.imag)
     for l_idx, r_idx, o_idx in sh.iter_indices(left.shape, right.shape, res.shape):
         scalar_l = in_stype(left[l_idx])
         scalar_r = in_stype(right[r_idx])

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -948,6 +948,14 @@ def test_ceil(x):
     unary_assert_against_refimpl("ceil", x, out, math.ceil, strict_check=True)
 
 
+@given(xps.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
+def test_conj(x):
+    out = xp.conj(x)
+    ph.assert_dtype("conj", x.dtype, out.dtype)
+    ph.assert_shape("conj", out.shape, x.shape)
+    unary_assert_against_refimpl("conj", x, out, operator.methodcaller("conjugate"))
+
+
 @given(xps.arrays(dtype=all_floating_dtypes(), shape=hh.shapes()))
 def test_cos(x):
     out = xp.cos(x)

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -262,7 +262,7 @@ def unary_assert_against_refimpl(
         expr_template = func_name + "({})={}"
     in_stype = dh.get_scalar_type(in_.dtype)
     if res_stype is None:
-        res_stype = in_stype
+        res_stype = dh.get_scalar_type(res.dtype)
     if res.dtype == xp.bool:
         m, M = (None, None)
     elif res.dtype in dh.complex_dtypes:
@@ -334,7 +334,7 @@ def binary_assert_against_refimpl(
         expr_template = func_name + "({}, {})={}"
     in_stype = dh.get_scalar_type(left.dtype)
     if res_stype is None:
-        res_stype = in_stype
+        res_stype = dh.get_scalar_type(left.dtype)
     if res_stype is None:
         res_stype = in_stype
     if res.dtype == xp.bool:
@@ -412,7 +412,7 @@ def right_scalar_assert_against_refimpl(
         return  # short-circuit here as there will be nothing to test
     in_stype = dh.get_scalar_type(left.dtype)
     if res_stype is None:
-        res_stype = in_stype
+        res_stype = dh.get_scalar_type(left.dtype)
     if res_stype is None:
         res_stype = in_stype
     if res.dtype == xp.bool:
@@ -1100,6 +1100,14 @@ def test_greater_equal(ctx, data):
     )
 
 
+@given(xps.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
+def test_imag(x):
+    out = xp.imag(x)
+    ph.assert_dtype("imag", x.dtype, out.dtype, dh.dtype_components[x.dtype])
+    ph.assert_shape("imag", out.shape, x.shape)
+    unary_assert_against_refimpl("imag", x, out, operator.attrgetter("imag"))
+
+
 @given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
 def test_isfinite(x):
     out = xp.isfinite(x)
@@ -1341,6 +1349,14 @@ def test_pow(ctx, data):
     # Values testing pow is too finicky
 
 
+@given(xps.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
+def test_real(x):
+    out = xp.real(x)
+    ph.assert_dtype("real", x.dtype, out.dtype, dh.dtype_components[x.dtype])
+    ph.assert_shape("real", out.shape, x.shape)
+    unary_assert_against_refimpl("real", x, out, operator.attrgetter("real"))
+
+
 @pytest.mark.parametrize("ctx", make_binary_params("remainder", dh.real_dtypes))
 @given(data=st.data())
 def test_remainder(ctx, data):
@@ -1366,8 +1382,7 @@ def test_round(x):
     unary_assert_against_refimpl("round", x, out, round, strict_check=True)
 
 
-# TODO: https://github.com/data-apis/array-api/issues/545
-@given(xps.arrays(dtype=xps.real_dtypes(), shape=hh.shapes(), elements=finite_kw))
+@given(xps.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes(), elements=finite_kw))
 def test_sign(x):
     out = xp.sign(x)
     ph.assert_dtype("sign", x.dtype, out.dtype)

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -90,14 +90,25 @@ def mock_int_dtype(n: int, dtype: DataType) -> int:
     return n
 
 
-def isclose(a: float, b: float, *, rel_tol: float = 0.25, abs_tol: float = 1) -> bool:
+def isclose(
+    a: float,
+    b: float,
+    M: float,
+    *,
+    rel_tol: float = 0.25,
+    abs_tol: float = 1,
+) -> bool:
     """Wraps math.isclose with very generous defaults.
 
     This is useful for many floating-point operations where the spec does not
     make accuracy requirements.
     """
-    if not (math.isfinite(a) and math.isfinite(b)):
-        raise ValueError(f"{a=} and {b=}, but input must be finite")
+    if math.isnan(a) or math.isnan(b):
+        raise ValueError(f"{a=} and {b=}, but input must be non-NaN")
+    if math.isinf(a):
+        return math.isinf(b) or abs(b) > math.log(M)
+    elif math.isinf(b):
+        return math.isinf(a) or abs(a) > math.log(M)
     return math.isclose(a, b, rel_tol=rel_tol, abs_tol=abs_tol)
 
 
@@ -288,10 +299,10 @@ def unary_assert_against_refimpl(
                 f"{f_i}={scalar_i}"
             )
             if res.dtype in dh.complex_dtypes:
-                assert isclose(scalar_o.real, expected.real), msg
-                assert isclose(scalar_o.imag, expected.imag), msg
+                assert isclose(scalar_o.real, expected.real, M), msg
+                assert isclose(scalar_o.imag, expected.imag, M), msg
             else:
-                assert isclose(scalar_o, expected), msg
+                assert isclose(scalar_o, expected, M), msg
         else:
             assert scalar_o == expected, (
                 f"{f_o}={scalar_o}, but should be {expr} [{func_name}()]\n"
@@ -364,10 +375,10 @@ def binary_assert_against_refimpl(
                 f"{f_l}={scalar_l}, {f_r}={scalar_r}"
             )
             if res.dtype in dh.complex_dtypes:
-                assert isclose(scalar_o.real, expected.real), msg
-                assert isclose(scalar_o.imag, expected.imag), msg
+                assert isclose(scalar_o.real, expected.real, M), msg
+                assert isclose(scalar_o.imag, expected.imag, M), msg
             else:
-                assert isclose(scalar_o, expected), msg
+                assert isclose(scalar_o, expected, M), msg
         else:
             assert scalar_o == expected, (
                 f"{f_o}={scalar_o}, but should be {expr} [{func_name}()]\n"
@@ -437,10 +448,10 @@ def right_scalar_assert_against_refimpl(
                 f"{f_l}={scalar_l}"
             )
             if res.dtype in dh.complex_dtypes:
-                assert isclose(scalar_o.real, expected.real), msg
-                assert isclose(scalar_o.imag, expected.imag), msg
+                assert isclose(scalar_o.real, expected.real, M), msg
+                assert isclose(scalar_o.imag, expected.imag, M), msg
             else:
-                assert isclose(scalar_o, expected), msg
+                assert isclose(scalar_o, expected, M), msg
         else:
             assert scalar_o == expected, (
                 f"{f_o}={scalar_o}, but should be {expr} [{func_name}()]\n"

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -12,7 +12,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.control import reject
 
-from . import COMPLEX_VER, _array_module as xp, api_version
+from . import _array_module as xp, api_version
 from . import array_helpers as ah
 from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
@@ -36,7 +36,7 @@ def boolean_and_all_integer_dtypes() -> st.SearchStrategy[DataType]:
 
 def all_floating_dtypes() -> st.SearchStrategy[DataType]:
     strat = xps.floating_dtypes()
-    if api_version >= COMPLEX_VER:
+    if api_version >= "2022.12":
         strat |= xps.complex_dtypes()
     return strat
 
@@ -502,7 +502,7 @@ def make_unary_params(
 ) -> List[Param[UnaryParamContext]]:
     if hh.FILTER_UNDEFINED_DTYPES:
         dtypes = [d for d in dtypes if not isinstance(d, xp._UndefinedStub)]
-    if api_version < COMPLEX_VER:
+    if api_version < "2022.12":
         dtypes = [d for d in dtypes if d not in dh.complex_dtypes]
     dtypes_strat = st.sampled_from(dtypes)
     strat = xps.arrays(dtype=dtypes_strat, shape=hh.shapes())
@@ -965,7 +965,7 @@ def test_ceil(x):
     unary_assert_against_refimpl("ceil", x, out, math.ceil, strict_check=True)
 
 
-if api_version >= COMPLEX_VER:
+if api_version >= "2022.12":
 
     @given(xps.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
     def test_conj(x):
@@ -1127,7 +1127,7 @@ def test_greater_equal(ctx, data):
     )
 
 
-if api_version >= COMPLEX_VER:
+if api_version >= "2022.12":
 
     @given(xps.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
     def test_imag(x):
@@ -1378,7 +1378,7 @@ def test_pow(ctx, data):
     # Values testing pow is too finicky
 
 
-if api_version >= COMPLEX_VER:
+if api_version >= "2022.12":
 
     @given(xps.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
     def test_real(x):

--- a/array_api_tests/test_set_functions.py
+++ b/array_api_tests/test_set_functions.py
@@ -1,4 +1,5 @@
 # TODO: disable if opted out, refactor things
+import cmath
 import math
 from collections import Counter, defaultdict
 
@@ -61,7 +62,7 @@ def test_unique_all(x):
 
     for idx in sh.ndindex(out.indices.shape):
         val = scalar_type(out.values[idx])
-        if math.isnan(val):
+        if cmath.isnan(val):
             break
         i = int(out.indices[idx])
         expected = firsts[val]
@@ -88,7 +89,7 @@ def test_unique_all(x):
     for idx in sh.ndindex(out.values.shape):
         val = scalar_type(out.values[idx])
         count = int(out.counts[idx])
-        if math.isnan(val):
+        if cmath.isnan(val):
             nans += 1
             assert count == 1, (
                 f"out.counts[{idx}]={count} for out.values[{idx}]={val}, "
@@ -225,7 +226,7 @@ def test_unique_values(x):
     nans = 0
     for idx in sh.ndindex(out.shape):
         val = scalar_type(out[idx])
-        if math.isnan(val):
+        if cmath.isnan(val):
             nans += 1
         else:
             assert val in distinct, f"out[{idx}]={val}, but {val} not in input array"

--- a/array_api_tests/test_sorting_functions.py
+++ b/array_api_tests/test_sorting_functions.py
@@ -1,4 +1,4 @@
-import math
+import cmath
 from typing import Set
 
 import pytest
@@ -26,7 +26,7 @@ def assert_scalar_in_set(
     **kw,
 ):
     out_repr = "out" if idx == () else f"out[{idx}]"
-    if math.isnan(out):
+    if cmath.isnan(out):
         raise NotImplementedError()
     msg = f"{out_repr}={out}, but should be in {set_} [{func_name}({ph.fmt_kw(kw)})]"
     assert out in set_, msg

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -35,10 +35,6 @@ from . import shape_helpers as sh
 from . import xps
 from ._array_module import mod as xp
 from .stubs import category_to_funcs
-from .test_operators_and_elementwise_functions import (
-    oneway_broadcastable_shapes,
-    oneway_promotable_dtypes,
-)
 
 pytestmark = pytest.mark.ci
 
@@ -1281,8 +1277,8 @@ def test_binary(func_name, func, case, x1, x2, data):
 
 @pytest.mark.parametrize("iop_name, iop, case", iop_params)
 @given(
-    oneway_dtypes=oneway_promotable_dtypes(dh.float_dtypes),
-    oneway_shapes=oneway_broadcastable_shapes(),
+    oneway_dtypes=hh.oneway_promotable_dtypes(dh.float_dtypes),
+    oneway_shapes=hh.oneway_broadcastable_shapes(),
     data=st.data(),
 )
 def test_iop(iop_name, iop, case, oneway_dtypes, oneway_shapes, data):

--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -1,3 +1,4 @@
+import cmath
 import math
 from typing import Optional
 
@@ -162,7 +163,7 @@ def test_prod(x, data):
     scalar_type = dh.get_scalar_type(out.dtype)
     for indices, out_idx in zip(sh.axes_ndindex(x.shape, _axes), sh.ndindex(out.shape)):
         prod = scalar_type(out[out_idx])
-        assume(math.isfinite(prod))
+        assume(cmath.isfinite(prod))
         elements = []
         for idx in indices:
             s = scalar_type(x[idx])
@@ -267,7 +268,7 @@ def test_sum(x, data):
     scalar_type = dh.get_scalar_type(out.dtype)
     for indices, out_idx in zip(sh.axes_ndindex(x.shape, _axes), sh.ndindex(out.shape)):
         sum_ = scalar_type(out[out_idx])
-        assume(math.isfinite(sum_))
+        assume(cmath.isfinite(sum_))
         elements = []
         for idx in indices:
             s = scalar_type(x[idx])

--- a/array_api_tests/typing.py
+++ b/array_api_tests/typing.py
@@ -12,8 +12,8 @@ __all__ = [
 ]
 
 DataType = Type[Any]
-Scalar = Union[bool, int, float]
-ScalarType = Union[Type[bool], Type[int], Type[float]]
+Scalar = Union[bool, int, float, complex]
+ScalarType = Union[Type[bool], Type[int], Type[float], Type[complex]]
 Array = Any
 Shape = Tuple[int, ...]
 AtomicIndex = Union[int, "ellipsis", slice, None]  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-json-report
-hypothesis>=6.62.1
+hypothesis>=6.68.0
 ndindex>=1.6


### PR DESCRIPTION
Resolves #20 with the introduced marker `min_version(api_version)`, so tests only run when specified with a later version. The env var `ARRAY_API_TESTS_VERSION` allows one to specify a version to test with, which currently defaults to `xp.__array_api_version__` and fallsback to `"2021.12"`.

Covers complex testing for extended and new functions in the `2022.12` spec. Does not cover outside of that yet, nor complex special cases—something for a future PR.

Realise I need to update Hypothesis first so it recognizes `2022.12` before I'd want this merged.