### PR TITLE
`test_isdtype`

### DIFF
--- a/array_api_tests/_array_module.py
+++ b/array_api_tests/_array_module.py
@@ -62,7 +62,7 @@ _dtypes = [
 ]
 _constants = ["e", "inf", "nan", "pi"]
 _funcs = [f.__name__ for funcs in stubs.category_to_funcs.values() for f in funcs]
-_funcs += ["take"]  # TODO: bump spec and update array-api-tests to new spec layout
+_funcs += ["take", "isdtype"]  # TODO: bump spec and update array-api-tests to new spec layout
 _top_level_attrs = _dtypes + _constants + _funcs + stubs.EXTENSIONS
 
 for attr in _top_level_attrs:

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -24,6 +24,7 @@ __all__ = [
     "bool_and_all_int_dtypes",
     "dtype_to_name",
     "dtype_to_scalars",
+    "kind_to_dtypes",
     "is_int_dtype",
     "is_float_dtype",
     "get_scalar_type",
@@ -137,6 +138,17 @@ dtype_to_scalars = EqualityMapping(
         *[(d, [int, float]) for d in float_dtypes],
     ]
 )
+
+
+kind_to_dtypes = {
+    "bool": [xp.bool],
+    "signed integer": int_dtypes,
+    "unsigned integer": uint_dtypes,
+    "integral": all_int_dtypes,
+    "real floating": float_dtypes,
+    "complex floating": complex_dtypes,
+    "numeric": numeric_dtypes,
+}
 
 
 def is_int_dtype(dtype):


### PR DESCRIPTION
New territory here, but is currently passing for https://github.com/data-apis/array-api-compat/pull/32