### PR TITLE
`hh.reject_overflow()`

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -1,4 +1,6 @@
+import re
 import itertools
+from contextlib import contextmanager
 from functools import reduce
 from math import sqrt
 from operator import mul
@@ -477,3 +479,14 @@ def axes(ndim: int) -> SearchStrategy[Optional[Union[int, Shape]]]:
         axes_strats.append(integers(-ndim, ndim - 1))
         axes_strats.append(xps.valid_tuple_axes(ndim))
     return one_of(axes_strats)
+
+
+@contextmanager
+def reject_overflow():
+    try:
+        yield
+    except Exception as e:
+        if isinstance(e, OverflowError) or re.search("[Oo]verflow", str(e)):
+            reject()
+        else:
+            raise e

--- a/array_api_tests/meta/test_utils.py
+++ b/array_api_tests/meta/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import given, reject
+from hypothesis import given
 from hypothesis import strategies as st
 
 from .. import _array_module as xp
@@ -105,10 +105,8 @@ def test_fmt_idx(idx, expected):
 
 @given(x=st.integers(), dtype=xps.unsigned_integer_dtypes() | xps.integer_dtypes())
 def test_int_to_dtype(x, dtype):
-    try:
+    with hh.reject_overflow():
         d = xp.asarray(x, dtype=dtype)
-    except OverflowError:
-        reject()
     assert mock_int_dtype(x, dtype) == d
 
 

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -8,7 +8,7 @@ from enum import Enum, auto
 from typing import Callable, List, NamedTuple, Optional, Sequence, TypeVar, Union
 
 import pytest
-from hypothesis import assume, given, reject
+from hypothesis import assume, given
 from hypothesis import strategies as st
 
 from . import _array_module as xp, api_version
@@ -740,10 +740,8 @@ def test_add(ctx, data):
     left = data.draw(ctx.left_strat, label=ctx.left_sym)
     right = data.draw(ctx.right_strat, label=ctx.right_sym)
 
-    try:
+    with hh.reject_overflow():
         res = ctx.func(left, right)
-    except OverflowError:
-        reject()
 
     binary_param_assert_dtype(ctx, left, right, res)
     binary_param_assert_shape(ctx, left, right, res)
@@ -1327,10 +1325,8 @@ def test_pow(ctx, data):
         if dh.is_int_dtype(right.dtype):
             assume(xp.all(right >= 0))
 
-    try:
+    with hh.reject_overflow():
         res = ctx.func(left, right)
-    except OverflowError:
-        reject()
 
     binary_param_assert_dtype(ctx, left, right, res)
     binary_param_assert_shape(ctx, left, right, res)
@@ -1425,10 +1421,8 @@ def test_subtract(ctx, data):
     left = data.draw(ctx.left_strat, label=ctx.left_sym)
     right = data.draw(ctx.right_strat, label=ctx.right_sym)
 
-    try:
+    with hh.reject_overflow():
         res = ctx.func(left, right)
-    except OverflowError:
-        reject()
 
     binary_param_assert_dtype(ctx, left, right, res)
     binary_param_assert_shape(ctx, left, right, res)

--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -5,7 +5,6 @@ from typing import Optional
 import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
-from hypothesis.control import reject
 
 from . import _array_module as xp
 from . import dtype_helpers as dh
@@ -127,10 +126,8 @@ def test_prod(x, data):
     )
     keepdims = kw.get("keepdims", False)
 
-    try:
+    with hh.reject_overflow():
         out = xp.prod(x, **kw)
-    except OverflowError:
-        reject()
 
     dtype = kw.get("dtype", None)
     if dtype is None:
@@ -234,10 +231,8 @@ def test_sum(x, data):
     )
     keepdims = kw.get("keepdims", False)
 
-    try:
+    with hh.reject_overflow():
         out = xp.sum(x, **kw)
-    except OverflowError:
-        reject()
 
     dtype = kw.get("dtype", None)
     if dtype is None:


### PR DESCRIPTION
WIP as pretty sure this is broken, but attempts to reject examples with overflow errors that don't come as `OverflowError`, i.e. in PyTorch which returns `RuntimeError` instead. Resolves #178.