### PR TITLE
Remove use of `_UndefinedStub` in `dtype_helpers.py`

### DIFF
--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -13,6 +13,7 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
+from ._array_module import mod as _xp
 from .typing import DataType, Index, Param, Scalar, ScalarType, Shape
 
 pytestmark = pytest.mark.ci
@@ -241,21 +242,27 @@ def test_setitem_masking(shape, data):
             )
 
 
-def make_param(method_name: str, dtype: DataType, stype: ScalarType) -> Param:
+def make_scalar_casting_param(
+    method_name: str, dtype_name: DataType, stype: ScalarType
+) -> Param:
     return pytest.param(
-        method_name, dtype, stype, id=f"{method_name}({dh.dtype_to_name[dtype]})"
+        method_name, dtype_name, stype, id=f"{method_name}({dtype_name})"
     )
 
 
 @pytest.mark.parametrize(
-    "method_name, dtype, stype",
-    [make_param("__bool__", xp.bool, bool)]
-    + [make_param("__int__", d, int) for d in dh._filter_stubs(*dh.all_int_dtypes)]
-    + [make_param("__index__", d, int) for d in dh._filter_stubs(*dh.all_int_dtypes)]
-    + [make_param("__float__", d, float) for d in dh.float_dtypes],
+    "method_name, dtype_name, stype",
+    [make_scalar_casting_param("__bool__", "bool", bool)]
+    + [make_scalar_casting_param("__int__", n, int) for n in dh.all_int_names]
+    + [make_scalar_casting_param("__index__", n, int) for n in dh.all_int_names]
+    + [make_scalar_casting_param("__float__", n, float) for n in dh.float_names],
 )
 @given(data=st.data())
-def test_scalar_casting(method_name, dtype, stype, data):
+def test_scalar_casting(method_name, dtype_name, stype, data):
+    try:
+        dtype = getattr(_xp, dtype_name)
+    except AttributeError as e:
+        pytest.skip(str(e))
     x = data.draw(xps.arrays(dtype, shape=()), label="x")
     method = getattr(x, method_name)
     out = method()

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -11,6 +11,7 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
+from ._array_module import mod as _xp
 from .typing import DataType
 
 pytestmark = pytest.mark.ci
@@ -141,12 +142,12 @@ def test_can_cast(_from, to, data):
         assert out == expected, f"{out=}, but should be {expected} {f_func}"
 
 
-def make_dtype_id(dtype: DataType) -> str:
-    return dh.dtype_to_name[dtype]
-
-
-@pytest.mark.parametrize("dtype", dh.float_dtypes, ids=make_dtype_id)
-def test_finfo(dtype):
+@pytest.mark.parametrize("dtype_name", dh.float_names)
+def test_finfo(dtype_name):
+    try:
+        dtype = getattr(_xp, dtype_name)
+    except AttributeError as e:
+        pytest.skip(str(e))
     out = xp.finfo(dtype)
     f_func = f"[finfo({dh.dtype_to_name[dtype]})]"
     for attr, stype in [
@@ -164,8 +165,12 @@ def test_finfo(dtype):
     # TODO: test values
 
 
-@pytest.mark.parametrize("dtype", dh._filter_stubs(*dh.all_int_dtypes), ids=make_dtype_id)
-def test_iinfo(dtype):
+@pytest.mark.parametrize("dtype_name", dh.all_int_names)
+def test_iinfo(dtype_name):
+    try:
+        dtype = getattr(_xp, dtype_name)
+    except AttributeError as e:
+        pytest.skip(str(e))
     out = xp.iinfo(dtype)
     f_func = f"[iinfo({dh.dtype_to_name[dtype]})]"
     for attr in ["bits", "max", "min"]:


### PR DESCRIPTION
This is mighty useful as currently we have two classes of the dtype helpers—those that consume stubs and those who don't, which is hard to keep track. This unifies the approach of the helpers so they are only constructed with available dtypes.

If this was merged it'd remove the need for #181, although we might want to add automatic xfails when parametrized dtypes (i.e. in `test_iinfo`) are not found.