### PR TITLE
Skip `test_matmul` and `test_remainder`

### DIFF
--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -277,6 +277,7 @@ def test_inv(x):
 
     # TODO: Test that the result is actually the inverse
 
+@pytest.mark.skip(reason="flaky")
 @given(
     *two_mutual_arrays(dh.real_dtypes)
 )

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1347,6 +1347,7 @@ if api_version >= "2022.12":
         unary_assert_against_refimpl("real", x, out, operator.attrgetter("real"))
 
 
+@pytest.mark.skip(reason="flaky")
 @pytest.mark.parametrize("ctx", make_binary_params("remainder", dh.real_dtypes))
 @given(data=st.data())
 def test_remainder(ctx, data):


### PR DESCRIPTION
Both seem to fail the test suite sometimes, can look into later and leave skipped for now.