### PR TITLE
CI: bump numpy version to fix errors

### DIFF
--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - name: Checkout array-api-tests
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==1.22.1
+        python -m pip install numpy==1.26.2
         python -m pip install -r requirements.txt
     - name: Run the test suite
       env:

--- a/numpy-skips.txt
+++ b/numpy-skips.txt
@@ -12,6 +12,9 @@ array_api_tests/test_set_functions.py
 # newaxis not included in numpy namespace as of v1.26.2
 array_api_tests/test_constants.py::test_newaxis
 
+# linalg.solve issue in numpy.array_api as of v1.26.2 (see numpy#25146)
+array_api_tests/test_linalg.py::test_solve
+
 # https://github.com/numpy/numpy/issues/21373
 array_api_tests/test_array_object.py::test_getitem
 

--- a/numpy-skips.txt
+++ b/numpy-skips.txt
@@ -9,6 +9,9 @@ array_api_tests/test_linalg.py::test_trace
 # https://github.com/numpy/numpy/issues/20326#issuecomment-1012380448
 array_api_tests/test_set_functions.py
 
+# newaxis not included in numpy namespace as of v1.26.2
+array_api_tests/test_constants.py::test_newaxis
+
 # https://github.com/numpy/numpy/issues/21373
 array_api_tests/test_array_object.py::test_getitem
 


### PR DESCRIPTION
The CI tests check for `iinfo.dtype` and `finfo.dtype`, which were added to NumPy in https://github.com/numpy/numpy/pull/23881 and therefore require a newer NumPy version.

Since newer numpy versions are not compatible with Python 3.8, I also bumped the Python versions used by the CI.