### PR TITLE
MAINT: Remove legacy hook marks

### DIFF
--- a/reporting.py
+++ b/reporting.py
@@ -10,7 +10,7 @@ import warnings
 
 from hypothesis.strategies import SearchStrategy
 
-from pytest import mark, fixture
+import pytest
 try:
     import pytest_jsonreport # noqa
 except ImportError:
@@ -44,7 +44,7 @@ def to_json_serializable(o):
 
     return o
 
-@mark.optionalhook
+@pytest.hookimpl(optionalhook=True)
 def pytest_metadata(metadata):
     """
     Additional global metadata for --json-report.
@@ -52,7 +52,7 @@ def pytest_metadata(metadata):
     metadata['array_api_tests_module'] = xp.mod_name
     metadata['array_api_tests_version'] = __version__
 
-@fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def add_extra_json_metadata(request, json_metadata):
     """
     Additional per-test metadata for --json-report
@@ -91,7 +91,7 @@ def add_extra_json_metadata(request, json_metadata):
 
     request.addfinalizer(finalizer)
 
-@mark.optionalhook
+@pytest.hookimpl(optionalhook=True)
 def pytest_json_modifyreport(json_report):
     # Deduplicate warnings. These duplicate warnings can cause the file size
     # to become huge. For instance, a warning from np.bool which is emitted


### PR DESCRIPTION
Hi!
When running the test suite I get an error when collecting tests:
```
pytest.PytestDeprecationWarning: The hookimpl pytest_json_modifyreport uses old-style configuration options (marks or attributes).
Please use the pytest.hookimpl(optionalhook=True) decorator instead
 to configure the hooks.
 See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
 at /home/runner/work/numpy/numpy/array-api-tests/reporting.py:94
Error: Process completed with exit code 1.
```
The first CI run in my fork: https://github.com/mtsokol/numpy/actions/runs/6894487016/job/18756394760

Here's a small patch that updates decorators. 

