### PR TITLE
symmetric_matrices: draw from finite if necessary

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -251,6 +251,8 @@ two_mutually_broadcastable_shapes = mutually_broadcastable_shapes(2)
 def symmetric_matrices(draw, dtypes=xps.floating_dtypes(), finite=True):
     shape = draw(square_matrix_shapes)
     dtype = draw(dtypes)
+    if not isinstance(finite, bool):
+        finite = draw(finite)
     elements = {'allow_nan': False, 'allow_infinity': False} if finite else None
     a = draw(xps.arrays(dtype=dtype, shape=shape, elements=elements))
     upper = xp.triu(a)

--- a/array_api_tests/meta/test_hypothesis_helpers.py
+++ b/array_api_tests/meta/test_hypothesis_helpers.py
@@ -129,11 +129,9 @@ def test_specified_kwargs():
 
 
 
-@given(m=hh.symmetric_matrices(hh.shared_floating_dtypes,
-                                     finite=st.shared(st.booleans(), key='finite')),
-       dtype=hh.shared_floating_dtypes,
-       finite=st.shared(st.booleans(), key='finite'))
-def test_symmetric_matrices(m, dtype, finite):
+@given(finite=st.booleans(), dtype=xps.floating_dtypes(), data=st.data())
+def test_symmetric_matrices(finite, dtype, data):
+    m = data.draw(hh.symmetric_matrices(st.just(dtype), finite=finite))
     assert m.dtype == dtype
     # TODO: This part of this test should be part of the .mT test
     ah.assert_exactly_equal(m, m.mT)


### PR DESCRIPTION
Currently, running `array_api_tests/meta/test_hypothesis_helpers.py::test_symmetric_matrices` produces a warning:
```
hypothesis.errors.HypothesisWarning: bool(shared(booleans(), key='finite')) is always True, did you mean to draw a value?
```
The reason is that this test passes a boolean hypothesis parameter to the `symmetric_matrices` utility, and we must `draw` that parameter before using it. Other tests pass a raw boolean value to the function, so a reasonable fix is to only `draw` the value if it's not already a `bool` instance.

With the change in this PR, the test no longer leads to a warning.