### PR TITLE
Update `test_sign` for complex inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,10 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# IDE
+.idea/
+.vscode/
+
 # mkdocs documentation
 /site
 

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -267,6 +267,7 @@ def unary_assert_against_refimpl(
         f_i = sh.fmt_idx("x", idx)
         f_o = sh.fmt_idx("out", idx)
         expr = expr_template.format(f_i, expected)
+        # TODO: strict check floating results too
         if strict_check == False or res.dtype in dh.all_float_dtypes:
             msg = (
                 f"{f_o}={scalar_o}, but should be roughly {expr} [{func_name}()]\n"
@@ -1383,8 +1384,15 @@ def test_sign(x):
     out = xp.sign(x)
     ph.assert_dtype("sign", in_dtype=x.dtype, out_dtype=out.dtype)
     ph.assert_shape("sign", out_shape=out.shape, expected=x.shape)
-    refimpl = lambda x: x / xp.abs(x) if x != 0 else 0
-    unary_assert_against_refimpl("sign", x, out, refimpl, filter_=lambda s: s != 0)
+    refimpl = lambda x: x / math.abs(x) if x != 0 else 0
+    unary_assert_against_refimpl(
+        "sign",
+        x,
+        out,
+        refimpl,
+        filter_=lambda s: s != 0,
+        strict_check=True,
+    )
 
 
 @given(hh.arrays(dtype=hh.all_floating_dtypes(), shape=hh.shapes()))

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1383,9 +1383,8 @@ def test_sign(x):
     out = xp.sign(x)
     ph.assert_dtype("sign", in_dtype=x.dtype, out_dtype=out.dtype)
     ph.assert_shape("sign", out_shape=out.shape, expected=x.shape)
-    unary_assert_against_refimpl(
-        "sign", x, out, lambda s: math.copysign(1, s), filter_=lambda s: s != 0
-    )
+    refimpl = lambda x: x / xp.abs(x) if x != 0 else 0
+    unary_assert_against_refimpl("sign", x, out, refimpl, filter_=lambda s: s != 0)
 
 
 @given(hh.arrays(dtype=hh.all_floating_dtypes(), shape=hh.shapes()))


### PR DESCRIPTION
Hi!
This PR updates `test_sign` for complex inputs to [align with Array API](https://data-apis.org/array-api/latest/API_specification/generated/array_api.sign.html).

Relevant discussion: https://github.com/numpy/numpy/pull/25441#issuecomment-1873998082