### PR TITLE
Short-circuit with vectorisation `ph.assert_array_elements()`

### DIFF
--- a/array_api_tests/meta/test_pytest_helpers.py
+++ b/array_api_tests/meta/test_pytest_helpers.py
@@ -20,3 +20,7 @@ def test_assert_array_elements():
         ph.assert_array_elements("mixed sign zeros", out=xp.asarray(0.0), expected=xp.asarray(-0.0))
     with raises(AssertionError):
         ph.assert_array_elements("mixed sign zeros", out=xp.asarray(-0.0), expected=xp.asarray(0.0))
+
+    ph.assert_array_elements("nans", out=xp.asarray(float("nan")), expected=xp.asarray(float("nan")))
+    with raises(AssertionError):
+        ph.assert_array_elements("nan and zero", out=xp.asarray(float("nan")), expected=xp.asarray(0.0))

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -459,6 +459,13 @@ def assert_array_elements(
     dh.result_type(out.dtype, expected.dtype)  # sanity check
     assert_shape(func_name, out_shape=out.shape, expected=expected.shape, kw=kw)  # sanity check
     f_func = f"[{func_name}({fmt_kw(kw)})]"
+
+    match = (out == expected)
+    if xp.all(match):
+        return
+
+    # In case of mismatch, generate a more helpful error. Cycling through all indices is
+    # costly in some array api implementations, so we only do this in the case of a failure.
     if out.dtype in dh.real_float_dtypes:
         for idx in sh.ndindex(out.shape):
             at_out = out[idx]
@@ -480,6 +487,4 @@ def assert_array_elements(
             _assert_float_element(xp.real(at_out), xp.real(at_expected), msg)
             _assert_float_element(xp.imag(at_out), xp.imag(at_expected), msg)
     else:
-        assert xp.all(
-            out == expected
-        ), f"{out_repr} not as expected {f_func}\n{out_repr}={out!r}\n{expected=}"
+        assert xp.all(match), f"{out_repr} not as expected {f_func}\n{out_repr}={out!r}\n{expected=}"

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -485,7 +485,7 @@ def assert_array_elements(
         >>> assert xp.all(out == x)
 
     """
-    __tracebackhide__ = True
+    # __tracebackhide__ = True
     dh.result_type(out.dtype, expected.dtype)  # sanity check
     assert_shape(func_name, out_shape=out.shape, expected=expected.shape, kw=kw)  # sanity check
     f_func = f"[{func_name}({fmt_kw(kw)})]"
@@ -495,8 +495,8 @@ def assert_array_elements(
         if _real_float_strict_equals(out, expected):
             return
     elif out.dtype in dh.complex_dtypes:
-        real_match = _real_float_strict_equals(out.real, expected.real)
-        imag_match = _real_float_strict_equals(out.imag, expected.imag)
+        real_match = _real_float_strict_equals(xp.real(out), xp.real(expected))
+        imag_match = _real_float_strict_equals(xp.imag(out), xp.imag(expected))
         if real_match and imag_match:
             return
     else:

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Union
 from . import _array_module as xp
 from . import dtype_helpers as dh
 from . import shape_helpers as sh
-from . import stubs, api_version
+from . import stubs
 from . import xp as _xp
 from .typing import Array, DataType, Scalar, ScalarType, Shape
 
@@ -429,13 +429,13 @@ def _real_float_strict_equals(out: Array, expected: Array) -> bool:
 
     # Test sign of zeroes if xp.signbit() available, otherwise ignore as it's
     # not that big of a deal for the perf costs.
-    if api_version >= "2023.12" and hasattr(_xp, "signbit"):
+    if hasattr(_xp, "signbit"):
         out_zero_mask = out == 0
-        out_sign_mask = xp.signbit(out)
+        out_sign_mask = _xp.signbit(out)
         out_pos_zero_mask = out_zero_mask & out_sign_mask
         out_neg_zero_mask = out_zero_mask & ~out_sign_mask
         expected_zero_mask = expected == 0
-        expected_sign_mask = xp.signbit(expected)
+        expected_sign_mask = _xp.signbit(expected)
         expected_pos_zero_mask = expected_zero_mask & expected_sign_mask
         expected_neg_zero_mask = expected_zero_mask & ~expected_sign_mask
         pos_zero_match = out_pos_zero_mask == expected_pos_zero_mask

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -354,14 +354,14 @@ def test_eye(n_rows, n_cols, kw):
         ph.assert_kw_dtype("eye", kw_dtype=kw["dtype"], out_dtype=out.dtype)
     _n_cols = n_rows if n_cols is None else n_cols
     ph.assert_shape("eye", out_shape=out.shape, expected=(n_rows, _n_cols), kw=dict(n_rows=n_rows, n_cols=n_cols))
-    f_func = f"[eye({n_rows=}, {n_cols=})]"
-    for i in range(n_rows):
-        for j in range(_n_cols):
-            f_indexed_out = f"out[{i}, {j}]={out[i, j]}"
-            if j - i == kw.get("k", 0):
-                assert out[i, j] == 1, f"{f_indexed_out}, should be 1 {f_func}"
-            else:
-                assert out[i, j] == 0, f"{f_indexed_out}, should be 0 {f_func}"
+    k = kw.get("k", 0)
+    expected = xp.asarray(
+        [[1 if j - i == k else 0 for j in range(_n_cols)] for i in range(n_rows)],
+        dtype=out.dtype  # Note: dtype already checked above.
+    )
+    if expected.size == 0:
+        expected = xp.reshape(expected, (n_rows, _n_cols))
+    ph.assert_array_elements("eye", out=out, expected=expected, kw=kw)
 
 
 default_unsafe_dtypes = [xp.uint64]


### PR DESCRIPTION
And general `test_eye` improvements. Carries on the work by @jakevdp in #200 (separate PR to make things easier to track).

~Requires `signbit` released in the `2023.12` spec, which isn't even supported yet in array API adoptions like `jax.experimental.array_api`. Probably what I'll do is ignore asserting pos/neg zeros for most of the tests where it's not really relevant, so we get the vectorisation benefits regardless of API version and adoption. I'll leave that for a future PR as I'd just want to mull that over, and want to see what the shape of vectorising everything looks like first anywho. This PR is essentially a proof of concept to be applied everywhere possible.~ Let's just ignore the `signbit` stuff if not available as the immediate perf benefits for libraries probably always trumps testing signed zero stuff.