### PR TITLE
Avoid passing a list of axes to tensordot

### DIFF
--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -768,6 +768,7 @@ def _test_tensordot_stacks(x1, x2, kw, res):
             indices = [range(len(s))[i] for i in a]
             repl = dict(zip(sorted(indices), range(len(indices))))
             res_axes.append(tuple(repl[i] for i in indices))
+        res_axes = tuple(res_axes)
 
     for ((i,), (j,)), (res_idx,) in zip(
             itertools.product(


### PR DESCRIPTION
cupy has logic that fails if axis is not a tuple. The standard type annotations only require axes to be a tuple.