### PR TITLE
Faster default runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,6 @@ jobs:
       env:
         ARRAY_API_TESTS_MODULE: array_api_strict
       run: |
-        pytest -v -rxXfE --skips-file array-api-strict-skips.txt array_api_tests/
+        pytest -v -rxXfE --skips-file array-api-strict-skips.txt array_api_tests/ --hypothesis-disable-deadline
         # We also have internal tests that isn't really necessary for adopters
         pytest -v -rxXfE meta_tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,6 @@ jobs:
       env:
         ARRAY_API_TESTS_MODULE: array_api_strict
       run: |
-        pytest -v -rxXfE --skips-file array-api-strict-skips.txt array_api_tests/ --hypothesis-disable-deadline
+        pytest -v -rxXfE --skips-file array-api-strict-skips.txt array_api_tests/
         # We also have internal tests that isn't really necessary for adopters
         pytest -v -rxXfE meta_tests/

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ jobs:
 > There are several ways to avoid this problem:
 >
 > - Increase the maximum number of examples, e.g., by adding `--max-examples
->   200` to the test command (the default is `100`, see below). This will
+>   200` to the test command (the default is `20`, see below). This will
 >   make it more likely that the failing case will be found, but it will also
 >   make the tests take longer to run.
 > - Don't use `-o xfail_strict=True`. This will make it so that if an XFAIL
@@ -275,7 +275,7 @@ jobs:
 The tests make heavy use
 [Hypothesis](https://hypothesis.readthedocs.io/en/latest/). You can configure
 how many examples are generated using the `--max-examples` flag, which
-defaults to `100`. Lower values can be useful for quick checks, and larger
+defaults to `20`. Lower values can be useful for quick checks, and larger
 values should result in more rigorous runs. For example, `--max-examples
 10_000` may find bugs where default runs don't but will take much longer to
 run.

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -119,6 +119,7 @@ def _test_namedtuple(res, fields, func_name):
         assert hasattr(res, field), f"{func_name}() result namedtuple doesn't have the '{field}' field"
         assert res[i] is getattr(res, field), f"{func_name}() result namedtuple '{field}' field is not in position {i}"
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=positive_definite_matrices(),
@@ -175,6 +176,7 @@ def cross_args(draw, dtype_objects=dh.real_dtypes):
     )
     return draw(arrays1), draw(arrays2), kw
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     cross_args()
@@ -209,6 +211,7 @@ def test_cross(x1_x2_kw):
     # vectors.
     _test_stacks(linalg.cross, x1, x2, dims=1, matrix_axes=(axis,), res=res, true_val=exact_cross)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=arrays(dtype=all_floating_dtypes(), shape=square_matrix_shapes),
@@ -224,6 +227,7 @@ def test_det(x):
 
     # TODO: Test that res actually corresponds to the determinant of x
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=arrays(dtype=xps.scalar_dtypes(), shape=matrix_shapes()),
@@ -261,6 +265,7 @@ def test_diagonal(x, kw):
 
     _test_stacks(linalg.diagonal, x, **kw, res=res, dims=1, true_val=true_diag)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(x=symmetric_matrices(finite=True))
 def test_eigh(x):
@@ -299,6 +304,7 @@ def test_eigh(x):
     # TODO: Test that res actually corresponds to the eigenvalues and
     # eigenvectors of x
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(x=symmetric_matrices(finite=True))
 def test_eigvalsh(x):
@@ -319,6 +325,7 @@ def test_eigvalsh(x):
 
     # TODO: Test that res actually corresponds to the eigenvalues of x
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(x=invertible_matrices())
 def test_inv(x):
@@ -372,6 +379,7 @@ def _test_matmul(namespace, x1, x2):
                                expected=stack_shape + (x1.shape[-2], x2.shape[-1]))
         _test_stacks(matmul, x1, x2, res=res)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     *two_mutual_arrays(dh.real_dtypes)
@@ -379,12 +387,14 @@ def _test_matmul(namespace, x1, x2):
 def test_linalg_matmul(x1, x2):
     return _test_matmul(linalg, x1, x2)
 
+@pytest.mark.unvectorized
 @given(
     *two_mutual_arrays(dh.real_dtypes)
 )
 def test_matmul(x1, x2):
     return _test_matmul(_array_module, x1, x2)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=finite_matrices(),
@@ -410,6 +420,7 @@ def test_matrix_norm(x, kw):
                  res=res)
 
 matrix_power_n = shared(integers(-100, 100), key='matrix_power n')
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     # Generate any square matrix if n >= 0 but only invertible matrices if n < 0
@@ -433,6 +444,7 @@ def test_matrix_power(x, n):
     func = lambda x: linalg.matrix_power(x, n)
     _test_stacks(func, x, res=res, true_val=true_val)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=finite_matrices(shape=rtol_shared_matrix_shapes),
@@ -457,6 +469,7 @@ def _test_matrix_transpose(namespace, x):
 
     _test_stacks(matrix_transpose, x, res=res, true_val=true_val)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=arrays(dtype=xps.scalar_dtypes(), shape=matrix_shapes()),
@@ -464,6 +477,7 @@ def _test_matrix_transpose(namespace, x):
 def test_linalg_matrix_transpose(x):
     return _test_matrix_transpose(linalg, x)
 
+@pytest.mark.unvectorized
 @given(
     x=arrays(dtype=xps.scalar_dtypes(), shape=matrix_shapes()),
 )
@@ -503,6 +517,7 @@ def test_outer(x1, x2):
 def test_pinv(x, kw):
     linalg.pinv(x, **kw)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=arrays(dtype=all_floating_dtypes(), shape=matrix_shapes()),
@@ -545,6 +560,7 @@ def test_qr(x, kw):
     # Check that R is upper-triangular.
     assert_exactly_equal(R, _array_module.triu(R))
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=arrays(dtype=all_floating_dtypes(), shape=square_matrix_shapes),
@@ -617,6 +633,7 @@ def solve_args() -> Tuple[SearchStrategy[Array], SearchStrategy[Array]]:
     x2 = arrays(shape=x2_shapes, dtype=mutual_dtypes.map(lambda pair: pair[1]))
     return x1, x2
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(*solve_args())
 def test_solve(x1, x2):
@@ -635,6 +652,7 @@ def test_solve(x1, x2):
     ph.assert_result_shape("solve", in_shapes=[x1.shape, x2.shape],
                            out_shape=res.shape, expected=expected_shape)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=finite_matrices(),
@@ -685,6 +703,7 @@ def test_svd(x, kw):
     _test_stacks(lambda x: linalg.svd(x, **kw).S, x, dims=1, res=S)
     _test_stacks(lambda x: linalg.svd(x, **kw).Vh, x, res=Vh)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=finite_matrices(),
@@ -818,6 +837,7 @@ def _test_tensordot(namespace, x1, x2, kw):
                            expected=result_shape)
     _test_tensordot_stacks(x1, x2, kw, res)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     *two_mutual_arrays(dh.numeric_dtypes, two_shapes=tensordot_shapes()),
@@ -826,6 +846,7 @@ def _test_tensordot(namespace, x1, x2, kw):
 def test_linalg_tensordot(x1, x2, kw):
     _test_tensordot(linalg, x1, x2, kw)
 
+@pytest.mark.unvectorized
 @given(
     *two_mutual_arrays(dh.numeric_dtypes, two_shapes=tensordot_shapes()),
     tensordot_kw,
@@ -833,6 +854,7 @@ def test_linalg_tensordot(x1, x2, kw):
 def test_tensordot(x1, x2, kw):
     _test_tensordot(_array_module, x1, x2, kw)
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=arrays(dtype=xps.numeric_dtypes(), shape=matrix_shapes()),
@@ -910,6 +932,7 @@ def _test_vecdot(namespace, x1, x2, data):
                  matrix_axes=(axis,), true_val=true_val)
 
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     *two_mutual_arrays(dh.numeric_dtypes, mutually_broadcastable_shapes(2, min_dims=1)),
@@ -918,6 +941,7 @@ def _test_vecdot(namespace, x1, x2, data):
 def test_linalg_vecdot(x1, x2, data):
     _test_vecdot(linalg, x1, x2, data)
 
+@pytest.mark.unvectorized
 @given(
     *two_mutual_arrays(dh.numeric_dtypes, mutually_broadcastable_shapes(2, min_dims=1)),
     data(),
@@ -929,6 +953,7 @@ def test_vecdot(x1, x2, data):
 # spec, so we just limit to reasonable values here.
 max_ord = 100
 
+@pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
     x=arrays(dtype=all_floating_dtypes(), shape=shapes(min_side=1)),

--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -46,6 +46,7 @@ def assert_array_ndindex(
             assert out[out_idx] == x[x_idx], msg
 
 
+@pytest.mark.unvectorized
 @given(
     dtypes=hh.mutually_promotable_dtypes(None, dtypes=dh.numeric_dtypes),
     base_shape=hh.shapes(),

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -494,6 +494,7 @@ def parse_result(result_str: str) -> Tuple[UnaryCheck, str]:
 class Case(Protocol):
     cond_expr: str
     result_expr: str
+    raw_case: Optional[str]
 
     def cond(self, *args) -> bool:
         ...
@@ -532,6 +533,7 @@ class UnaryCase(Case):
     cond_from_dtype: FromDtypeFunc
     cond: UnaryCheck
     check_result: UnaryResultCheck
+    raw_case: Optional[str] = field(default=None)
 
 
 r_unary_case = re.compile("If ``x_i`` is (.+), the result is (.+)")
@@ -674,6 +676,7 @@ def parse_unary_case_block(case_block: str) -> List[UnaryCase]:
                 cond_from_dtype=cond_from_dtype,
                 result_expr=result_expr,
                 check_result=check_result,
+                raw_case=case_str,
             )
             cases.append(case)
         else:
@@ -700,6 +703,7 @@ class BinaryCase(Case):
     x2_cond_from_dtype: FromDtypeFunc
     cond: BinaryCond
     check_result: BinaryResultCheck
+    raw_case: Optional[str] = field(default=None)
 
 
 r_binary_case = re.compile("If (.+), the result (.+)")
@@ -1058,6 +1062,7 @@ def parse_binary_case(case_str: str) -> BinaryCase:
         x2_cond_from_dtype=x2_cond_from_dtype,
         result_expr=result_expr,
         check_result=check_result,
+        raw_case=case_str,
     )
 
 

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -941,11 +941,17 @@ def parse_binary_case(case_str: str) -> BinaryCase:
                 def partial_cond(i1: float, i2: float) -> bool:
                     return math.copysign(1, i1) == math.copysign(1, i2)
 
+                x1_cond_from_dtypes.append(BoundFromDtype(kwargs={"min_value": 1}))
+                x2_cond_from_dtypes.append(BoundFromDtype(kwargs={"min_value": 1}))
+
             elif value_str == "different mathematical signs":
                 partial_expr = "copysign(1, x1_i) != copysign(1, x2_i)"
 
                 def partial_cond(i1: float, i2: float) -> bool:
                     return math.copysign(1, i1) != math.copysign(1, i2)
+
+                x1_cond_from_dtypes.append(BoundFromDtype(kwargs={"min_value": 1}))
+                x2_cond_from_dtypes.append(BoundFromDtype(kwargs={"max_value": -1}))
 
             else:
                 unary_cond, expr_template, cond_from_dtype = parse_cond(value_str)

--- a/conftest.py
+++ b/conftest.py
@@ -86,13 +86,13 @@ def pytest_configure(config):
         "unvectorized: asserts against values via element-wise iteration (not performative!)",
     )
     # Hypothesis
-    profile_settings = {
-        "max_examples": config.getoption("--hypothesis-max-examples"),
-        "derandomize": config.getoption("--hypothesis-derandomize"),
-    }
-    if config.getoption("--hypothesis-disable-deadline"):
-        profile_settings["deadline"] = None
-    settings.register_profile("array-api-tests", **profile_settings)
+    deadline = None if config.getoption("--hypothesis-disable-deadline") else 800
+    settings.register_profile(
+        "array-api-tests",
+        max_examples=config.getoption("--hypothesis-max-examples"),
+        derandomize=config.getoption("--hypothesis-derandomize"),
+        deadline=deadline,
+    )
     settings.load_profile("array-api-tests")
     # CI
     if config.getoption("--ci"):

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,8 @@ def pytest_addoption(parser):
         "--hypothesis-max-examples",
         "--max-examples",
         action="store",
-        default=100,
+        default=20,
+        type=int,
         help="set the Hypothesis max_examples setting",
     )
     # Hypothesis deadline

--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,6 @@ from array_api_tests._array_module import _UndefinedStub
 
 from reporting import pytest_metadata, pytest_json_modifyreport, add_extra_json_metadata # noqa
 
-settings.register_profile("xp_default", deadline=800)
 
 def pytest_addoption(parser):
     # Hypothesis max examples
@@ -87,21 +86,14 @@ def pytest_configure(config):
         "unvectorized: asserts against values via element-wise iteration (not performative!)",
     )
     # Hypothesis
-    hypothesis_max_examples = config.getoption("--hypothesis-max-examples")
-    disable_deadline = config.getoption("--hypothesis-disable-deadline")
-    derandomize = config.getoption("--hypothesis-derandomize")
-    profile_settings = {}
-    if hypothesis_max_examples is not None:
-        profile_settings["max_examples"] = int(hypothesis_max_examples)
-    if disable_deadline:
+    profile_settings = {
+        "max_examples": config.getoption("--hypothesis-max-examples"),
+        "derandomize": config.getoption("--hypothesis-derandomize"),
+    }
+    if config.getoption("--hypothesis-disable-deadline"):
         profile_settings["deadline"] = None
-    if derandomize:
-        profile_settings["derandomize"] = True
-    if profile_settings:
-        settings.register_profile("xp_override", **profile_settings)
-        settings.load_profile("xp_override")
-    else:
-        settings.load_profile("xp_default")
+    settings.register_profile("array-api-tests", **profile_settings)
+    settings.load_profile("array-api-tests")
     # CI
     if config.getoption("--ci"):
         warnings.warn(
@@ -156,7 +148,7 @@ def pytest_collection_modifyitems(config, items):
 
     disabled_exts = config.getoption("--disable-extension")
     disabled_dds = config.getoption("--disable-data-dependent-shapes")
-    unvectorized_max_examples = math.ceil(math.log(int(config.getoption("--hypothesis-max-examples")) or 50))
+    unvectorized_max_examples = math.ceil(math.log(config.getoption("--hypothesis-max-examples")))
 
     # 2. Iterate through items and apply markers accordingly
     # ------------------------------------------------------


### PR DESCRIPTION
Some changes that significantly speed-up the run of the test suite:
* Defaults max examples to 20
* Only runs one example for main special case tests
* More tests appropiately marked with `unvectorized`