### PR TITLE
When `xp.bool` unavailable patch `xp.bool_` (underscore)

### DIFF
--- a/array_api_tests/__init__.py
+++ b/array_api_tests/__init__.py
@@ -11,7 +11,7 @@ __all__ = ["xp", "api_version", "xps"]
 
 
 # You can comment the following out and instead import the specific array module
-# you want to test, e.g. `import numpy.array_api as xp`.
+# you want to test, e.g. `import array_api_strict as xp`.
 if "ARRAY_API_TESTS_MODULE" in os.environ:
     xp_name = os.environ["ARRAY_API_TESTS_MODULE"]
     _module, _sub = xp_name, None
@@ -31,6 +31,17 @@ else:
         "No array module specified - either edit __init__.py or set the "
         "ARRAY_API_TESTS_MODULE environment variable."
     )
+
+
+# If xp.bool is not available, like in some versions of NumPy and CuPy, try
+# patching in xp.bool_.
+try:
+    xp.bool
+except AttributeError as e:
+    if hasattr(xp, "bool_"):
+        xp.bool = xp.bool_
+    else:
+        raise e
 
 
 # We monkey patch floats() to always disable subnormals as they are out-of-scope


### PR DESCRIPTION
Inspired by #251, this PR enables testing of latest released NumPy and CuPy versions.