### PR TITLE
Reset the max-examples default back to 100

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 from functools import lru_cache
 from pathlib import Path
 import argparse
-import math
 import warnings
 import os
 

--- a/conftest.py
+++ b/conftest.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser):
         "--hypothesis-max-examples",
         "--max-examples",
         action="store",
-        default=20,
+        default=100,
         type=int,
         help="set the Hypothesis max_examples setting",
     )

--- a/conftest.py
+++ b/conftest.py
@@ -148,7 +148,7 @@ def pytest_collection_modifyitems(config, items):
 
     disabled_exts = config.getoption("--disable-extension")
     disabled_dds = config.getoption("--disable-data-dependent-shapes")
-    unvectorized_max_examples = math.ceil(math.log(config.getoption("--hypothesis-max-examples")))
+    unvectorized_max_examples = config.getoption("--hypothesis-max-examples")//10
 
     # 2. Iterate through items and apply markers accordingly
     # ------------------------------------------------------


### PR DESCRIPTION
The tests run fast enough now that there's no need to lower this to 20.

See the discussion at #246.