### PR TITLE
Add a sanity check that signbit works

### DIFF
--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -421,7 +421,8 @@ def assert_fill(
         assert xp.all(xp.equal(out, xp.asarray(fill_value, dtype=dtype))), msg
 
 
-def _has_signbit() -> bool:
+def _has_functional_signbit() -> bool:
+    # signbit can be available but not implemented (e.g., in array-api-strict)
     if not hasattr(_xp, "signbit"):
         return False
     try:
@@ -438,7 +439,7 @@ def _real_float_strict_equals(out: Array, expected: Array) -> bool:
 
     # Test sign of zeroes if xp.signbit() available, otherwise ignore as it's
     # not that big of a deal for the perf costs.
-    if _has_signbit():
+    if _has_functional_signbit():
         out_zero_mask = out == 0
         out_sign_mask = _xp.signbit(out)
         out_pos_zero_mask = out_zero_mask & out_sign_mask

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -421,6 +421,15 @@ def assert_fill(
         assert xp.all(xp.equal(out, xp.asarray(fill_value, dtype=dtype))), msg
 
 
+def _has_signbit() -> bool:
+    if not hasattr(_xp, "signbit"):
+        return False
+    try:
+        assert _xp.all(_xp.signbit(_xp.asarray(0.0)) == False)
+    except:
+        return False
+    return True
+
 def _real_float_strict_equals(out: Array, expected: Array) -> bool:
     nan_mask = xp.isnan(out)
     if not xp.all(nan_mask == xp.isnan(expected)):
@@ -429,7 +438,7 @@ def _real_float_strict_equals(out: Array, expected: Array) -> bool:
 
     # Test sign of zeroes if xp.signbit() available, otherwise ignore as it's
     # not that big of a deal for the perf costs.
-    if hasattr(_xp, "signbit"):
+    if _has_signbit():
         out_zero_mask = out == 0
         out_sign_mask = _xp.signbit(out)
         out_pos_zero_mask = out_zero_mask & out_sign_mask


### PR DESCRIPTION
The array-api-strict package disables signbit at runtime when the API version is set to 2022.12. This happens when the function is called, so the hasattr check would pass even though the function call fails.