### PR TITLE
Handle runs of sub-tests where no warnings arise

### DIFF
--- a/reporting.py
+++ b/reporting.py
@@ -103,7 +103,7 @@ def pytest_json_modifyreport(json_report):
     # doesn't store a full stack of where it was issued from. The resulting
     # warnings will be in order of the first time each warning is issued since
     # collections.Counter is ordered just like dict().
-    counted_warnings = Counter([frozenset(i.items()) for i in json_report['warnings']])
+    counted_warnings = Counter([frozenset(i.items()) for i in json_report.get('warnings', dict())])
     deduped_warnings = [{**dict(i), 'count': counted_warnings[i]} for i in counted_warnings]
 
     json_report['warnings'] = deduped_warnings


### PR DESCRIPTION
Running individual tests of the test suite may lead to runs where no warnings are produced, and that triggers an exception.

This change handles this corner case.