### PR TITLE
Support skipping dtypes by setting ARRAY_API_TESTS_SKIP_DTYPES

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+select = F

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the test suite for array libraries adopting the [Python Array API
 standard](https://data-apis.org/array-api/latest).
 
-Keeping full coverage of the spec is an on-going priority as the Array API evolves. 
+Keeping full coverage of the spec is an on-going priority as the Array API evolves.
 Feedback and contributions are welcome!
 
 ## Quickstart
@@ -285,6 +285,19 @@ values should result in more rigorous runs. For example, `--max-examples
 10_000` may find bugs where default runs don't but will take much longer to
 run.
 
+#### Skipping Dtypes
+
+The test suite will automatically skip testing of inessential dtypes if they
+are not present on the array module namespace, but dtypes can also be skipped
+manually by setting the environment variable `ARRAY_API_TESTS_SKIP_DTYPES` to
+a comma separated list of dtypes to skip. For example
+
+```
+ARRAY_API_TESTS_SKIP_DTYPES=uint16,uint32,uint64 pytest array_api_tests/
+```
+
+Note that skipping certain essential dtypes such as `bool` and the default
+floating-point dtype is not supported.
 
 ## Contributing
 

--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -137,6 +137,34 @@ def assert_dtype(
     assert out_dtype == expected, msg
 
 
+def assert_float_to_complex_dtype(
+    func_name: str, *, in_dtype: DataType, out_dtype: DataType
+):
+    if in_dtype == xp.float32:
+        expected = xp.complex64
+    else:
+        assert in_dtype == xp.float64  # sanity check
+        expected = xp.complex128
+    assert_dtype(
+        func_name, in_dtype=in_dtype, out_dtype=out_dtype, expected=expected
+    )
+
+
+def assert_complex_to_float_dtype(
+    func_name: str, *, in_dtype: DataType, out_dtype: DataType, repr_name: str = "out.dtype"
+):
+    if in_dtype == xp.complex64:
+        expected = xp.float32
+    elif in_dtype == xp.complex128:
+        expected = xp.float64
+    else:
+        assert in_dtype in (xp.float32, xp.float64)  # sanity check
+        expected = in_dtype
+    assert_dtype(
+        func_name, in_dtype=in_dtype, out_dtype=out_dtype, expected=expected, repr_name=repr_name
+    )
+
+
 def assert_kw_dtype(
     func_name: str,
     *,

--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -13,7 +13,6 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
-from . import xp as _xp
 from .typing import DataType, Index, Param, Scalar, ScalarType, Shape
 
 

--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -75,7 +75,7 @@ def get_indexed_axes_and_out_shape(
     return tuple(axes_indices), tuple(out_shape)
 
 
-@given(shape=hh.shapes(), dtype=xps.scalar_dtypes(), data=st.data())
+@given(shape=hh.shapes(), dtype=hh.all_dtypes, data=st.data())
 def test_getitem(shape, dtype, data):
     zero_sided = any(side == 0 for side in shape)
     if zero_sided:
@@ -157,7 +157,7 @@ def test_setitem(shape, dtypes, data):
 @pytest.mark.data_dependent_shapes
 @given(hh.shapes(), st.data())
 def test_getitem_masking(shape, data):
-    x = data.draw(hh.arrays(xps.scalar_dtypes(), shape=shape), label="x")
+    x = data.draw(hh.arrays(hh.all_dtypes, shape=shape), label="x")
     mask_shapes = st.one_of(
         st.sampled_from([x.shape, ()]),
         st.lists(st.booleans(), min_size=x.ndim, max_size=x.ndim).map(
@@ -202,7 +202,7 @@ def test_getitem_masking(shape, data):
 @pytest.mark.unvectorized
 @given(hh.shapes(), st.data())
 def test_setitem_masking(shape, data):
-    x = data.draw(hh.arrays(xps.scalar_dtypes(), shape=shape), label="x")
+    x = data.draw(hh.arrays(hh.all_dtypes, shape=shape), label="x")
     key = data.draw(hh.arrays(dtype=xp.bool, shape=shape), label="key")
     value = data.draw(
         hh.from_dtype(x.dtype) | hh.arrays(dtype=x.dtype, shape=()), label="value"
@@ -252,18 +252,14 @@ def make_scalar_casting_param(
 
 
 @pytest.mark.parametrize(
-    "method_name, dtype_name, stype",
-    [make_scalar_casting_param("__bool__", "bool", bool)]
-    + [make_scalar_casting_param("__int__", n, int) for n in dh.all_int_names]
-    + [make_scalar_casting_param("__index__", n, int) for n in dh.all_int_names]
-    + [make_scalar_casting_param("__float__", n, float) for n in dh.real_float_names],
+    "method_name, dtype, stype",
+    [make_scalar_casting_param("__bool__", xp.bool, bool)]
+    + [make_scalar_casting_param("__int__", n, int) for n in dh.all_int_dtypes]
+    + [make_scalar_casting_param("__index__", n, int) for n in dh.all_int_dtypes]
+    + [make_scalar_casting_param("__float__", n, float) for n in dh.real_float_dtypes],
 )
 @given(data=st.data())
-def test_scalar_casting(method_name, dtype_name, stype, data):
-    try:
-        dtype = getattr(_xp, dtype_name)
-    except AttributeError as e:
-        pytest.skip(str(e))
+def test_scalar_casting(method_name, dtype, stype, data):
     x = data.draw(hh.arrays(dtype, shape=()), label="x")
     method = getattr(x, method_name)
     out = method()

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -77,7 +77,7 @@ def reals(min_value=None, max_value=None) -> st.SearchStrategy[Union[int, float]
 
 
 # TODO: support testing complex dtypes
-@given(dtype=st.none() | xps.real_dtypes(), data=st.data())
+@given(dtype=st.none() | hh.real_dtypes, data=st.data())
 def test_arange(dtype, data):
     if dtype is None or dh.is_float_dtype(dtype):
         start = data.draw(reals(), label="start")
@@ -198,7 +198,7 @@ def test_arange(dtype, data):
 @given(shape=hh.shapes(min_side=1), data=st.data())
 def test_asarray_scalars(shape, data):
     kw = data.draw(
-        hh.kwargs(dtype=st.none() | xps.scalar_dtypes(), copy=st.none()), label="kw"
+        hh.kwargs(dtype=st.none() | hh.all_dtypes, copy=st.none()), label="kw"
     )
     dtype = kw.get("dtype", None)
     if dtype is None:
@@ -312,7 +312,7 @@ def test_asarray_arrays(shape, dtypes, data):
             ), f"{f_out}, but should be {value} after x was mutated"
 
 
-@given(hh.shapes(), hh.kwargs(dtype=st.none() | xps.scalar_dtypes()))
+@given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.all_dtypes))
 def test_empty(shape, kw):
     out = xp.empty(shape, **kw)
     if kw.get("dtype", None) is None:
@@ -323,8 +323,8 @@ def test_empty(shape, kw):
 
 
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()),
-    kw=hh.kwargs(dtype=st.none() | xps.scalar_dtypes()),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes()),
+    kw=hh.kwargs(dtype=st.none() | hh.all_dtypes),
 )
 def test_empty_like(x, kw):
     out = xp.empty_like(x, **kw)
@@ -340,7 +340,7 @@ def test_empty_like(x, kw):
     n_cols=st.none() | hh.sqrt_sizes,
     kw=hh.kwargs(
         k=st.integers(),
-        dtype=xps.numeric_dtypes(),
+        dtype=hh.numeric_dtypes,
     ),
 )
 def test_eye(n_rows, n_cols, kw):
@@ -368,7 +368,7 @@ if dh.default_float == xp.float32:
     default_unsafe_dtypes.append(xp.float64)
 if dh.default_complex == xp.complex64:
     default_unsafe_dtypes.append(xp.complex64)
-default_safe_dtypes: st.SearchStrategy = xps.scalar_dtypes().filter(
+default_safe_dtypes: st.SearchStrategy = hh.all_dtypes.filter(
     lambda d: d not in default_unsafe_dtypes
 )
 
@@ -376,7 +376,7 @@ default_safe_dtypes: st.SearchStrategy = xps.scalar_dtypes().filter(
 @st.composite
 def full_fill_values(draw) -> Union[bool, int, float, complex]:
     kw = draw(
-        st.shared(hh.kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw")
+        st.shared(hh.kwargs(dtype=st.none() | hh.all_dtypes), key="full_kw")
     )
     dtype = kw.get("dtype", None) or draw(default_safe_dtypes)
     return draw(hh.from_dtype(dtype))
@@ -385,7 +385,7 @@ def full_fill_values(draw) -> Union[bool, int, float, complex]:
 @given(
     shape=hh.shapes(),
     fill_value=full_fill_values(),
-    kw=st.shared(hh.kwargs(dtype=st.none() | xps.scalar_dtypes()), key="full_kw"),
+    kw=st.shared(hh.kwargs(dtype=st.none() | hh.all_dtypes), key="full_kw"),
 )
 def test_full(shape, fill_value, kw):
     with hh.reject_overflow():
@@ -424,9 +424,9 @@ def test_full(shape, fill_value, kw):
     ph.assert_fill("full", fill_value=fill_value, dtype=dtype, out=out, kw=dict(fill_value=fill_value))
 
 
-@given(kw=hh.kwargs(dtype=st.none() | xps.scalar_dtypes()), data=st.data())
+@given(kw=hh.kwargs(dtype=st.none() | hh.all_dtypes), data=st.data())
 def test_full_like(kw, data):
-    dtype = kw.get("dtype", None) or data.draw(xps.scalar_dtypes(), label="dtype")
+    dtype = kw.get("dtype", None) or data.draw(hh.all_dtypes, label="dtype")
     x = data.draw(hh.arrays(dtype=dtype, shape=hh.shapes()), label="x")
     fill_value = data.draw(hh.from_dtype(dtype), label="fill_value")
     out = xp.full_like(x, fill_value, **kw)
@@ -444,7 +444,7 @@ finite_kw = {"allow_nan": False, "allow_infinity": False}
 
 @given(
     num=hh.sizes,
-    dtype=st.none() | xps.floating_dtypes(),
+    dtype=st.none() | hh.real_floating_dtypes,
     endpoint=st.booleans(),
     data=st.data(),
 )
@@ -492,7 +492,7 @@ def test_linspace(num, dtype, endpoint, data):
         ph.assert_array_elements("linspace", out=out, expected=expected)
 
 
-@given(dtype=xps.numeric_dtypes(), data=st.data())
+@given(dtype=hh.numeric_dtypes, data=st.data())
 def test_meshgrid(dtype, data):
     # The number and size of generated arrays is arbitrarily limited to prevent
     # meshgrid() running out of memory.
@@ -524,7 +524,7 @@ def make_one(dtype: DataType) -> Scalar:
         return True
 
 
-@given(hh.shapes(), hh.kwargs(dtype=st.none() | xps.scalar_dtypes()))
+@given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.all_dtypes))
 def test_ones(shape, kw):
     out = xp.ones(shape, **kw)
     if kw.get("dtype", None) is None:
@@ -538,8 +538,8 @@ def test_ones(shape, kw):
 
 
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()),
-    kw=hh.kwargs(dtype=st.none() | xps.scalar_dtypes()),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes()),
+    kw=hh.kwargs(dtype=st.none() | hh.all_dtypes),
 )
 def test_ones_like(x, kw):
     out = xp.ones_like(x, **kw)
@@ -562,7 +562,7 @@ def make_zero(dtype: DataType) -> Scalar:
         return False
 
 
-@given(hh.shapes(), hh.kwargs(dtype=st.none() | xps.scalar_dtypes()))
+@given(hh.shapes(), hh.kwargs(dtype=st.none() | hh.all_dtypes))
 def test_zeros(shape, kw):
     out = xp.zeros(shape, **kw)
     if kw.get("dtype", None) is None:
@@ -576,8 +576,8 @@ def test_zeros(shape, kw):
 
 
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()),
-    kw=hh.kwargs(dtype=st.none() | xps.scalar_dtypes()),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes()),
+    kw=hh.kwargs(dtype=st.none() | hh.all_dtypes),
 )
 def test_zeros_like(x, kw):
     out = xp.zeros_like(x, **kw)

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -11,7 +11,6 @@ from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
-from . import xp as _xp
 from .typing import DataType
 
 

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -17,7 +17,7 @@ from .typing import DataType
 
 # TODO: test with complex dtypes
 def non_complex_dtypes():
-    return xps.boolean_dtypes() | xps.real_dtypes()
+    return xps.boolean_dtypes() | hh.real_dtypes
 
 
 def float32(n: Union[int, float]) -> float:
@@ -69,7 +69,7 @@ def test_astype(x_dtype, dtype, kw, data):
 def test_broadcast_arrays(shapes, data):
     arrays = []
     for c, shape in enumerate(shapes, 1):
-        x = data.draw(hh.arrays(dtype=xps.scalar_dtypes(), shape=shape), label=f"x{c}")
+        x = data.draw(hh.arrays(dtype=hh.all_dtypes, shape=shape), label=f"x{c}")
         arrays.append(x)
 
     out = xp.broadcast_arrays(*arrays)
@@ -92,7 +92,7 @@ def test_broadcast_arrays(shapes, data):
     # TODO: test values
 
 
-@given(x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()), data=st.data())
+@given(x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes()), data=st.data())
 def test_broadcast_to(x, data):
     shape = data.draw(
         hh.mutually_broadcastable_shapes(1, base_shape=x.shape)
@@ -140,12 +140,8 @@ def test_can_cast(_from, to, data):
         assert out == expected, f"{out=}, but should be {expected} {f_func}"
 
 
-@pytest.mark.parametrize("dtype_name", dh.real_float_names)
-def test_finfo(dtype_name):
-    try:
-        dtype = getattr(_xp, dtype_name)
-    except AttributeError as e:
-        pytest.skip(str(e))
+@pytest.mark.parametrize("dtype", dh.real_float_dtypes)
+def test_finfo(dtype):
     out = xp.finfo(dtype)
     f_func = f"[finfo({dh.dtype_to_name[dtype]})]"
     for attr, stype in [
@@ -164,12 +160,8 @@ def test_finfo(dtype_name):
     # TODO: test values
 
 
-@pytest.mark.parametrize("dtype_name", dh.all_int_names)
-def test_iinfo(dtype_name):
-    try:
-        dtype = getattr(_xp, dtype_name)
-    except AttributeError as e:
-        pytest.skip(str(e))
+@pytest.mark.parametrize("dtype", dh.int_dtypes)
+def test_iinfo(dtype):
     out = xp.iinfo(dtype)
     f_func = f"[iinfo({dh.dtype_to_name[dtype]})]"
     for attr in ["bits", "max", "min"]:
@@ -183,12 +175,12 @@ def test_iinfo(dtype_name):
 
 
 def atomic_kinds() -> st.SearchStrategy[Union[DataType, str]]:
-    return xps.scalar_dtypes() | st.sampled_from(list(dh.kind_to_dtypes.keys()))
+    return hh.all_dtypes | st.sampled_from(list(dh.kind_to_dtypes.keys()))
 
 
 @pytest.mark.min_version("2022.12")
 @given(
-    dtype=xps.scalar_dtypes(),
+    dtype=hh.all_dtypes,
     kind=atomic_kinds() | st.lists(atomic_kinds(), min_size=1).map(tuple),
 )
 def test_isdtype(dtype, kind):

--- a/array_api_tests/test_indexing_functions.py
+++ b/array_api_tests/test_indexing_functions.py
@@ -7,13 +7,12 @@ from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
-from . import xps
 
 
 @pytest.mark.unvectorized
 @pytest.mark.min_version("2022.12")
 @given(
-    x=hh.arrays(xps.scalar_dtypes(), hh.shapes(min_dims=1, min_side=1)),
+    x=hh.arrays(hh.all_dtypes, hh.shapes(min_dims=1, min_side=1)),
     data=st.data(),
 )
 def test_take(x, data):

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -24,8 +24,9 @@ import itertools
 from typing import Tuple
 
 from .array_helpers import assert_exactly_equal, asarray
-from .hypothesis_helpers import (arrays, all_floating_dtypes, xps, shapes,
-                                 kwargs, matrix_shapes, square_matrix_shapes,
+from .hypothesis_helpers import (arrays, all_floating_dtypes, all_dtypes,
+                                 numeric_dtypes, xps, shapes, kwargs,
+                                 matrix_shapes, square_matrix_shapes,
                                  symmetric_matrices, SearchStrategy,
                                  positive_definite_matrices, MAX_ARRAY_SIZE,
                                  invertible_matrices, two_mutual_arrays,
@@ -231,7 +232,7 @@ def test_det(x):
 @pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
-    x=arrays(dtype=xps.scalar_dtypes(), shape=matrix_shapes()),
+    x=arrays(dtype=all_dtypes, shape=matrix_shapes()),
     # offset may produce an overflow if it is too large. Supporting offsets
     # that are way larger than the array shape isn't very important.
     kw=kwargs(offset=integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE))
@@ -413,7 +414,8 @@ def test_matrix_norm(x, kw):
         expected_shape = x.shape[:-2] + (1, 1)
     else:
         expected_shape = x.shape[:-2]
-    ph.assert_dtype("matrix_norm", in_dtype=x.dtype, out_dtype=res.dtype)
+    ph.assert_complex_to_float_dtype("matrix_norm", in_dtype=x.dtype,
+                                     out_dtype=res.dtype)
     ph.assert_result_shape("matrix_norm", in_shapes=[x.shape],
                            out_shape=res.shape, expected=expected_shape)
 
@@ -473,14 +475,14 @@ def _test_matrix_transpose(namespace, x):
 @pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
-    x=arrays(dtype=xps.scalar_dtypes(), shape=matrix_shapes()),
+    x=arrays(dtype=all_dtypes, shape=matrix_shapes()),
 )
 def test_linalg_matrix_transpose(x):
     return _test_matrix_transpose(linalg, x)
 
 @pytest.mark.unvectorized
 @given(
-    x=arrays(dtype=xps.scalar_dtypes(), shape=matrix_shapes()),
+    x=arrays(dtype=all_dtypes, shape=matrix_shapes()),
 )
 def test_matrix_transpose(x):
     return _test_matrix_transpose(_array_module, x)
@@ -672,8 +674,8 @@ def test_svd(x, kw):
 
     ph.assert_dtype("svd", in_dtype=x.dtype, out_dtype=U.dtype,
                     expected=x.dtype, repr_name="U.dtype")
-    ph.assert_dtype("svd", in_dtype=x.dtype, out_dtype=S.dtype,
-                    expected=x.dtype, repr_name="S.dtype")
+    ph.assert_complex_to_float_dtype("svd", in_dtype=x.dtype,
+                                      out_dtype=S.dtype, repr_name="S.dtype")
     ph.assert_dtype("svd", in_dtype=x.dtype, out_dtype=Vh.dtype,
                     expected=x.dtype, repr_name="Vh.dtype")
 
@@ -715,8 +717,8 @@ def test_svdvals(x):
     *stack, M, N = x.shape
     K = min(M, N)
 
-    ph.assert_dtype("svdvals", in_dtype=x.dtype, out_dtype=res.dtype,
-                    expected=x.dtype)
+    ph.assert_complex_to_float_dtype("svdvals", in_dtype=x.dtype,
+                                     out_dtype=res.dtype)
     ph.assert_result_shape("svdvals", in_shapes=[x.shape],
                            out_shape=res.shape,
                            expected=(*stack, K))
@@ -858,7 +860,7 @@ def test_tensordot(x1, x2, kw):
 @pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(
-    x=arrays(dtype=xps.numeric_dtypes(), shape=matrix_shapes()),
+    x=arrays(dtype=numeric_dtypes, shape=matrix_shapes()),
     # offset may produce an overflow if it is too large. Supporting offsets
     # that are way larger than the array shape isn't very important.
     kw=kwargs(offset=integers(-MAX_ARRAY_SIZE, MAX_ARRAY_SIZE))

--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -122,7 +122,7 @@ def test_concat(dtypes, base_shape, data):
 
 @pytest.mark.unvectorized
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=shared_shapes()),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=shared_shapes()),
     axis=shared_shapes().flatmap(
         # Generate both valid and invalid axis
         lambda s: st.integers(2 * (-len(s) - 1), 2 * len(s))
@@ -150,7 +150,7 @@ def test_expand_dims(x, axis):
 
 
 @pytest.mark.min_version("2023.12")
-@given(x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_dims=1)), data=st.data())
+@given(x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_dims=1)), data=st.data())
 def test_moveaxis(x, data):
     source = data.draw(
         st.integers(-x.ndim, x.ndim - 1) | xps.valid_tuple_axes(x.ndim), label="source"
@@ -177,7 +177,7 @@ def test_moveaxis(x, data):
 @pytest.mark.unvectorized
 @given(
     x=hh.arrays(
-        dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1).filter(lambda s: 1 in s)
+        dtype=hh.all_dtypes, shape=hh.shapes(min_side=1).filter(lambda s: 1 in s)
     ),
     data=st.data(),
 )
@@ -214,7 +214,7 @@ def test_squeeze(x, data):
 
 @pytest.mark.unvectorized
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes()),
     data=st.data(),
 )
 def test_flip(x, data):
@@ -239,7 +239,7 @@ def test_flip(x, data):
 
 @pytest.mark.unvectorized
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=shared_shapes(min_dims=1)),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=shared_shapes(min_dims=1)),
     axes=shared_shapes(min_dims=1).flatmap(
         lambda s: st.lists(
             st.integers(0, len(s) - 1),
@@ -280,7 +280,7 @@ def reshape_shapes(draw, shape):
 
 @pytest.mark.min_version("2023.12")
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_dims=1)),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_dims=1)),
     repeats=st.integers(1, 4),
 )
 def test_repeat(x, repeats):
@@ -295,7 +295,7 @@ def test_repeat(x, repeats):
 @pytest.mark.unvectorized
 @pytest.mark.skip("flaky")  # TODO: fix!
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(max_side=MAX_SIDE)),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(max_side=MAX_SIDE)),
     data=st.data(),
 )
 def test_reshape(x, data):
@@ -326,7 +326,7 @@ def roll_ndindex(shape: Shape, shifts: Tuple[int], axes: Tuple[int]) -> Iterator
 
 
 @pytest.mark.unvectorized
-@given(hh.arrays(dtype=xps.scalar_dtypes(), shape=shared_shapes()), st.data())
+@given(hh.arrays(dtype=hh.all_dtypes, shape=shared_shapes()), st.data())
 def test_roll(x, data):
     shift_strat = st.integers(-hh.MAX_ARRAY_SIZE, hh.MAX_ARRAY_SIZE)
     if x.ndim > 0:
@@ -413,7 +413,7 @@ def test_stack(shape, dtypes, kw, data):
 
 
 @pytest.mark.min_version("2023.12")
-@given(x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()), data=st.data())
+@given(x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes()), data=st.data())
 def test_tile(x, data):
     repetitions = data.draw(st.lists(st.integers(1, 4), min_size=1, max_size=x.ndim + 1).map(tuple), label="repetitions")
     out = xp.tile(x, repetitions)
@@ -422,7 +422,7 @@ def test_tile(x, data):
 
 
 @pytest.mark.min_version("2023.12")
-@given(x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_dims=1)), data=st.data())
+@given(x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_dims=1)), data=st.data())
 def test_unstack(x, data):
     axis = data.draw(st.integers(min_value=-x.ndim, max_value=x.ndim - 1), label="axis")
     kw = data.draw(hh.specified_kwargs(("axis", axis, 0)), label="kw")

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -25,16 +25,6 @@ from .typing import Array, DataType, Param, Scalar, ScalarType, Shape
 pytestmark = pytest.mark.unvectorized
 
 
-def all_integer_dtypes() -> st.SearchStrategy[DataType]:
-    """Returns a strategy for signed and unsigned integer dtype objects."""
-    return xps.unsigned_integer_dtypes() | xps.integer_dtypes()
-
-
-def boolean_and_all_integer_dtypes() -> st.SearchStrategy[DataType]:
-    """Returns a strategy for boolean and all integer dtype objects."""
-    return xps.boolean_dtypes() | all_integer_dtypes()
-
-
 def mock_int_dtype(n: int, dtype: DataType) -> int:
     """Returns equivalent of `n` that mocks `dtype` behaviour."""
     nbits = dh.dtype_nbits[dtype]
@@ -925,7 +915,7 @@ def test_bitwise_xor(ctx, data):
     binary_param_assert_against_refimpl(ctx, left, right, res, "^", refimpl)
 
 
-@given(hh.arrays(dtype=xps.real_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.real_dtypes, shape=hh.shapes()))
 def test_ceil(x):
     out = xp.ceil(x)
     ph.assert_dtype("ceil", in_dtype=x.dtype, out_dtype=out.dtype)
@@ -934,7 +924,7 @@ def test_ceil(x):
 
 
 @pytest.mark.min_version("2023.12")
-@given(hh.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.real_floating_dtypes, shape=hh.shapes()))
 def test_clip(x):
     # TODO: test min/max kwargs, adjust values testing accordingly
     out = xp.clip(x)
@@ -945,7 +935,7 @@ def test_clip(x):
 
 if api_version >= "2022.12":
 
-    @given(hh.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
+    @given(hh.arrays(dtype=hh.complex_dtypes, shape=hh.shapes()))
     def test_conj(x):
         out = xp.conj(x)
         ph.assert_dtype("conj", in_dtype=x.dtype, out_dtype=out.dtype)
@@ -1047,7 +1037,7 @@ def test_expm1(x):
     unary_assert_against_refimpl("expm1", x, out, math.expm1)
 
 
-@given(hh.arrays(dtype=xps.real_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.real_dtypes, shape=hh.shapes()))
 def test_floor(x):
     out = xp.floor(x)
     ph.assert_dtype("floor", in_dtype=x.dtype, out_dtype=out.dtype)
@@ -1125,7 +1115,7 @@ def test_hypot(x1, x2):
 
 if api_version >= "2022.12":
 
-    @given(hh.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
+    @given(hh.arrays(dtype=hh.complex_dtypes, shape=hh.shapes()))
     def test_imag(x):
         out = xp.imag(x)
         ph.assert_dtype("imag", in_dtype=x.dtype, out_dtype=out.dtype, expected=dh.dtype_components[x.dtype])
@@ -1133,7 +1123,7 @@ if api_version >= "2022.12":
         unary_assert_against_refimpl("imag", x, out, operator.attrgetter("imag"))
 
 
-@given(hh.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.numeric_dtypes, shape=hh.shapes()))
 def test_isfinite(x):
     out = xp.isfinite(x)
     ph.assert_dtype("isfinite", in_dtype=x.dtype, out_dtype=out.dtype, expected=xp.bool)
@@ -1141,7 +1131,7 @@ def test_isfinite(x):
     unary_assert_against_refimpl("isfinite", x, out, math.isfinite, res_stype=bool)
 
 
-@given(hh.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.numeric_dtypes, shape=hh.shapes()))
 def test_isinf(x):
     out = xp.isinf(x)
     ph.assert_dtype("isfinite", in_dtype=x.dtype, out_dtype=out.dtype, expected=xp.bool)
@@ -1149,7 +1139,7 @@ def test_isinf(x):
     unary_assert_against_refimpl("isinf", x, out, math.isinf, res_stype=bool)
 
 
-@given(hh.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.numeric_dtypes, shape=hh.shapes()))
 def test_isnan(x):
     out = xp.isnan(x)
     ph.assert_dtype("isnan", in_dtype=x.dtype, out_dtype=out.dtype, expected=xp.bool)
@@ -1392,7 +1382,7 @@ def test_pow(ctx, data):
 
 if api_version >= "2022.12":
 
-    @given(hh.arrays(dtype=xps.complex_dtypes(), shape=hh.shapes()))
+    @given(hh.arrays(dtype=hh.complex_dtypes, shape=hh.shapes()))
     def test_real(x):
         out = xp.real(x)
         ph.assert_dtype("real", in_dtype=x.dtype, out_dtype=out.dtype, expected=dh.dtype_components[x.dtype])
@@ -1418,7 +1408,7 @@ def test_remainder(ctx, data):
     binary_param_assert_against_refimpl(ctx, left, right, res, "%", operator.mod)
 
 
-@given(hh.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.numeric_dtypes, shape=hh.shapes()))
 def test_round(x):
     out = xp.round(x)
     ph.assert_dtype("round", in_dtype=x.dtype, out_dtype=out.dtype)
@@ -1427,7 +1417,7 @@ def test_round(x):
 
 
 @pytest.mark.min_version("2023.12")
-@given(hh.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.real_floating_dtypes, shape=hh.shapes()))
 def test_signbit(x):
     out = xp.signbit(x)
     ph.assert_dtype("signbit", in_dtype=x.dtype, out_dtype=out.dtype, expected=xp.bool)
@@ -1435,7 +1425,7 @@ def test_signbit(x):
     # TODO: values testing
 
 
-@given(hh.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes(), elements=finite_kw))
+@given(hh.arrays(dtype=hh.numeric_dtypes, shape=hh.shapes(), elements=finite_kw))
 def test_sign(x):
     out = xp.sign(x)
     ph.assert_dtype("sign", in_dtype=x.dtype, out_dtype=out.dtype)
@@ -1467,7 +1457,7 @@ def test_sinh(x):
     unary_assert_against_refimpl("sinh", x, out, math.sinh)
 
 
-@given(hh.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes()))
+@given(hh.arrays(dtype=hh.numeric_dtypes, shape=hh.shapes()))
 def test_square(x):
     out = xp.square(x)
     ph.assert_dtype("square", in_dtype=x.dtype, out_dtype=out.dtype)
@@ -1517,7 +1507,7 @@ def test_tanh(x):
     unary_assert_against_refimpl("tanh", x, out, math.tanh)
 
 
-@given(hh.arrays(dtype=xps.real_dtypes(), shape=xps.array_shapes()))
+@given(hh.arrays(dtype=hh.real_dtypes, shape=xps.array_shapes()))
 def test_trunc(x):
     out = xp.trunc(x)
     ph.assert_dtype("trunc", in_dtype=x.dtype, out_dtype=out.dtype)

--- a/array_api_tests/test_searching_functions.py
+++ b/array_api_tests/test_searching_functions.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.unvectorized
 
 @given(
     x=hh.arrays(
-        dtype=xps.real_dtypes(),
+        dtype=hh.real_dtypes,
         shape=hh.shapes(min_dims=1, min_side=1),
         elements={"allow_nan": False},
     ),
@@ -54,7 +54,7 @@ def test_argmax(x, data):
 
 @given(
     x=hh.arrays(
-        dtype=xps.real_dtypes(),
+        dtype=hh.real_dtypes,
         shape=hh.shapes(min_dims=1, min_side=1),
         elements={"allow_nan": False},
     ),
@@ -88,14 +88,14 @@ def test_argmin(x, data):
         ph.assert_scalar_equals("argmin", type_=int, idx=out_idx, out=min_i, expected=expected)
 
 
-@given(hh.arrays(dtype=xps.scalar_dtypes(), shape=()))
+@given(hh.arrays(dtype=hh.all_dtypes, shape=()))
 def test_nonzero_zerodim_error(x):
     with pytest.raises(Exception):
         xp.nonzero(x)
 
 
 @pytest.mark.data_dependent_shapes
-@given(hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_dims=1, min_side=1)))
+@given(hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_dims=1, min_side=1)))
 def test_nonzero(x):
     out = xp.nonzero(x)
     assert len(out) == x.ndim, f"{len(out)=}, but should be {x.ndim=}"

--- a/array_api_tests/test_set_functions.py
+++ b/array_api_tests/test_set_functions.py
@@ -11,12 +11,11 @@ from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
-from . import xps
 
 pytestmark = [pytest.mark.data_dependent_shapes, pytest.mark.unvectorized]
 
 
-@given(hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)))
+@given(hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_side=1)))
 def test_unique_all(x):
     out = xp.unique_all(x)
 
@@ -116,7 +115,7 @@ def test_unique_all(x):
         assert nans == expected, f"{nans} NaNs in out, but should be {expected}"
 
 
-@given(hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)))
+@given(hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_side=1)))
 def test_unique_counts(x):
     out = xp.unique_counts(x)
     assert hasattr(out, "values")
@@ -163,7 +162,7 @@ def test_unique_counts(x):
         assert nans == expected, f"{nans} NaNs in out, but should be {expected}"
 
 
-@given(hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)))
+@given(hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_side=1)))
 def test_unique_inverse(x):
     out = xp.unique_inverse(x)
     assert hasattr(out, "values")
@@ -216,7 +215,7 @@ def test_unique_inverse(x):
         assert nans == expected, f"{nans} NaNs in out.values, but should be {expected}"
 
 
-@given(hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)))
+@given(hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_side=1)))
 def test_unique_values(x):
     out = xp.unique_values(x)
     ph.assert_dtype("unique_values", in_dtype=x.dtype, out_dtype=out.dtype)

--- a/array_api_tests/test_sorting_functions.py
+++ b/array_api_tests/test_sorting_functions.py
@@ -33,7 +33,7 @@ def assert_scalar_in_set(
 @pytest.mark.unvectorized
 @given(
     x=hh.arrays(
-        dtype=xps.real_dtypes(),
+        dtype=hh.real_dtypes,
         shape=hh.shapes(min_dims=1, min_side=1),
         elements={"allow_nan": False},
     ),
@@ -94,7 +94,7 @@ def test_argsort(x, data):
 # TODO: Test with signed zeros and NaNs (and ignore them somehow)
 @given(
     x=hh.arrays(
-        dtype=xps.real_dtypes(),
+        dtype=hh.real_dtypes,
         shape=hh.shapes(min_dims=1, min_side=1),
         elements={"allow_nan": False},
     ),

--- a/array_api_tests/test_sorting_functions.py
+++ b/array_api_tests/test_sorting_functions.py
@@ -11,7 +11,6 @@ from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
-from . import xps
 from .typing import Scalar, Shape
 
 

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -1326,7 +1326,7 @@ def test_empty_arrays(func_name, expected):  # TODO: parse docstrings to get exp
     "func_name", [f.__name__ for f in category_to_funcs["statistical"]]
 )
 @given(
-    x=hh.arrays(dtype=xps.floating_dtypes(), shape=hh.shapes(min_side=1)),
+    x=hh.arrays(dtype=hh.real_floating_dtypes, shape=hh.shapes(min_side=1)),
     data=st.data(),
 )
 def test_nan_propagation(func_name, x, data):

--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -17,7 +17,7 @@ from .typing import DataType
 
 
 @pytest.mark.min_version("2023.12")
-@given(hh.arrays(dtype=xps.numeric_dtypes(), shape=hh.shapes(min_dims=1, max_dims=1)))
+@given(hh.arrays(dtype=hh.numeric_dtypes, shape=hh.shapes(min_dims=1, max_dims=1)))
 def test_cumulative_sum(x):
     # TODO: test kwargs + diff shapes, adjust shape and values testing accordingly
     out = xp.cumulative_sum(x)
@@ -36,7 +36,7 @@ def kwarg_dtypes(dtype: DataType) -> st.SearchStrategy[Optional[DataType]]:
 @pytest.mark.unvectorized
 @given(
     x=hh.arrays(
-        dtype=xps.real_dtypes(),
+        dtype=hh.real_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ),
@@ -66,7 +66,7 @@ def test_max(x, data):
 
 @given(
     x=hh.arrays(
-        dtype=xps.floating_dtypes(),
+        dtype=hh.real_floating_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ),
@@ -89,7 +89,7 @@ def test_mean(x, data):
 @pytest.mark.unvectorized
 @given(
     x=hh.arrays(
-        dtype=xps.real_dtypes(),
+        dtype=hh.real_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ),
@@ -120,7 +120,7 @@ def test_min(x, data):
 @pytest.mark.unvectorized
 @given(
     x=hh.arrays(
-        dtype=xps.numeric_dtypes(),
+        dtype=hh.numeric_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ),
@@ -172,7 +172,7 @@ def test_prod(x, data):
 @pytest.mark.skip(reason="flaky")  # TODO: fix!
 @given(
     x=hh.arrays(
-        dtype=xps.floating_dtypes(),
+        dtype=hh.real_floating_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ).filter(lambda x: math.prod(x.shape) >= 2),
@@ -209,7 +209,7 @@ def test_std(x, data):
 @pytest.mark.unvectorized
 @given(
     x=hh.arrays(
-        dtype=xps.numeric_dtypes(),
+        dtype=hh.numeric_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ),
@@ -262,7 +262,7 @@ def test_sum(x, data):
 @pytest.mark.skip(reason="flaky")  # TODO: fix!
 @given(
     x=hh.arrays(
-        dtype=xps.floating_dtypes(),
+        dtype=hh.real_floating_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ).filter(lambda x: math.prod(x.shape) >= 2),

--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -11,7 +11,7 @@ from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
-from . import api_version, xps
+from . import api_version
 from ._array_module import _UndefinedStub
 from .typing import DataType
 

--- a/array_api_tests/test_utility_functions.py
+++ b/array_api_tests/test_utility_functions.py
@@ -7,12 +7,11 @@ from . import dtype_helpers as dh
 from . import hypothesis_helpers as hh
 from . import pytest_helpers as ph
 from . import shape_helpers as sh
-from . import xps
 
 
 @pytest.mark.unvectorized
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes(min_side=1)),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes(min_side=1)),
     data=st.data(),
 )
 def test_all(x, data):
@@ -40,7 +39,7 @@ def test_all(x, data):
 
 @pytest.mark.unvectorized
 @given(
-    x=hh.arrays(dtype=xps.scalar_dtypes(), shape=hh.shapes()),
+    x=hh.arrays(dtype=hh.all_dtypes, shape=hh.shapes()),
     data=st.data(),
 )
 def test_any(x, data):


### PR DESCRIPTION
This requires using dtype strategies from hh instead of xps.

This also fixes some functions in linalg and fft that were incorrectly only tested against real floating-point dtypes, due to Hypothesis's confusing nomenclature of "floating_dtypes" being only real floating-point dtypes (and this also eliminates the use of Hypothesis's confusing "scalar_dtypes").

Fixes #265