### PR TITLE
Fix way to determine default_complex

### DIFF
--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -322,15 +322,16 @@ else:
     default_float = xp.asarray(float()).dtype
     if default_float not in real_float_dtypes:
         warn(f"inferred default float is {default_float!r}, which is not a float")
-    if api_version > "2021.12":
+
+    if not (hasattr(xp, "complex32") or hasattr(xp, "complex64")):
+        default_complex = None
+    else:
         default_complex = xp.asarray(complex()).dtype
         if default_complex not in complex_dtypes:
             warn(
                 f"inferred default complex is {default_complex!r}, "
                 "which is not a complex"
             )
-    else:
-        default_complex = None
 
 if dtype_nbits[default_int] == 32:
     default_uint = _name_to_dtype.get("uint32")

--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -322,16 +322,15 @@ else:
     default_float = xp.asarray(float()).dtype
     if default_float not in real_float_dtypes:
         warn(f"inferred default float is {default_float!r}, which is not a float")
-
-    if not (hasattr(xp, "complex32") or hasattr(xp, "complex64")):
-        default_complex = None
-    else:
+    if api_version > "2021.12" and ({'complex64', 'complex128'} - set(skip_dtypes)):
         default_complex = xp.asarray(complex()).dtype
         if default_complex not in complex_dtypes:
             warn(
                 f"inferred default complex is {default_complex!r}, "
                 "which is not a complex"
             )
+    else:
+        default_complex = None
 
 if dtype_nbits[default_int] == 32:
     default_uint = _name_to_dtype.get("uint32")

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -186,11 +186,11 @@ floating_dtypes = sampled_from(dh.all_float_dtypes)
 real_floating_dtypes = sampled_from(dh.real_float_dtypes)
 numeric_dtypes = sampled_from(dh.numeric_dtypes)
 # Note: this always returns complex dtypes, even if api_version < 2022.12
-complex_dtypes = sampled_from(dh.complex_dtypes)
+complex_dtypes: SearchStrategy[Any] | None = sampled_from(dh.complex_dtypes) if dh.complex_dtypes else None
 
 def all_floating_dtypes() -> SearchStrategy[DataType]:
     strat = floating_dtypes
-    if api_version >= "2022.12":
+    if api_version >= "2022.12" and complex_dtypes is not None:
         strat |= complex_dtypes
     return strat
 


### PR DESCRIPTION
The current test suite crashes during the collection time if the implementation in question does not support complex data types. This PR changes the way in which the `default_complex` type is determined to avoid the issue. Further discussion and context can be found [here](https://github.com/Quantco/ndonnx/pull/32). 