### PR TITLE
Remove `array-api-tests` prefix in ID matching

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -124,6 +124,8 @@ def xp_has_ext(ext: str) -> bool:
 
 
 def check_id_match(id_, pattern):
+    id_ = id_.removeprefix('array-api-tests/')
+
     if id_ == pattern:
         return True
     


### PR DESCRIPTION
This fixes failures I'm seeing when attempting to update array-api-tests in https://github.com/google/jax/pull/22903

Since the start of each skipped test name must be `array_api_tests`, I think this is always safe: https://github.com/data-apis/array-api-tests/blob/31468af33199d43b2d90f207bdffa68bfda47470/conftest.py#L159-L161