### PR TITLE
Avoid noisy JSON seralization warning for callables (e.g. numpy ufuncs)

### DIFF
--- a/reporting.py
+++ b/reporting.py
@@ -33,6 +33,8 @@ def to_json_serializable(o):
         return tuple(to_json_serializable(i) for i in o)
     if isinstance(o, list):
         return [to_json_serializable(i) for i in o]
+    if callable(o):
+        return repr(o)
 
     # Ensure everything is JSON serializable. If this warning is issued, it
     # means the given type needs to be added above if possible.


### PR DESCRIPTION
This avoids a bunch of warning log-spam, e.g.
```
$ ARRAY_API_TESTS_MODULE=numpy pytest -n auto array_api_tests

...

  /Users/vanderplas/github/array-api-tests/reporting.py:44: UserWarning: <function round at 0x105f66f70> (of type <class 'numpy._ArrayFunctionDispatcher'>) is not JSON-serializable. Using the repr instead.
    warnings.warn(f"{o!r} (of type {type(o)}) is not JSON-serializable. Using the repr instead.")

...
```
There are hundreds of such warnings that this change silences.