### PR TITLE
TST: filter out {invalid value, overflow, divide by zero} warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+filterwarnings =
+    ignore:invalid value encountered in:RuntimeWarning
+    ignore:overflow encountered in:RuntimeWarning
+    ignore:divide by zero encountered in:RuntimeWarning
+
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 filterwarnings =
+    # Ignore floating-point warnings from NumPy
     ignore:invalid value encountered in:RuntimeWarning
     ignore:overflow encountered in:RuntimeWarning
     ignore:divide by zero encountered in:RuntimeWarning


### PR DESCRIPTION
This is a minor usability tweak: IIUC (and please correct me if not), we are testing elementwise functions with various invalid arguments (nans, divide-by-zero, overflows) against "reference implementations". These operations generate walls of warnings, which are annoying if benign.
So mass-filter these warnings.
I suppose warning filters should be very specific to avoid masking genuine problems, so am adding the "message" argument to the filters.
In principle, one can make it even more specific if a bit more verbose--- and list warning-emitting functions explicitly: instead of

```
ignore:invalid value encountered in:RuntimeWarning
```

use

```
ignore:invalid value encountered in divide:RuntimeWarning
ignore:invalid value encountered in sqrt:RuntimeWarning
```
etc