### PR TITLE
stop skipping test_divide for complex inputs

### DIFF
--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1110,8 +1110,6 @@ def test_divide(ctx, data):
 
     binary_param_assert_dtype(ctx, left, right, res)
     binary_param_assert_shape(ctx, left, right, res)
-    if res.dtype in dh.complex_dtypes:
-        return  # TOOD: handle complex division
     binary_param_assert_against_refimpl(
         ctx,
         left,


### PR DESCRIPTION
Address the `test_divide (no complex numbers testing)` part of https://github.com/data-apis/array-api-tests/issues/301

Locally tests seem to pass, so I actually wonder what was meant by the TODO comment.