### PR TITLE
ENH: test astype with complex inputs

### DIFF
--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -19,10 +19,6 @@ def non_complex_dtypes():
     return xps.boolean_dtypes() | hh.real_dtypes
 
 
-def numeric_dtypes():
-    return xps.boolean_dtypes() | hh.real_dtypes | hh.complex_dtypes
-
-
 def float32(n: Union[int, float]) -> float:
     return struct.unpack("!f", struct.pack("!f", float(n)))[0]
 
@@ -32,8 +28,8 @@ def _float_match_complex(complex_dtype):
 
 
 @given(
-    x_dtype=numeric_dtypes(),
-    dtype=numeric_dtypes(),
+    x_dtype=hh.all_dtypes,
+    dtype=hh.all_dtypes,
     kw=hh.kwargs(copy=st.booleans()),
     data=st.data(),
 )


### PR DESCRIPTION
In fact, I'm not entirely sure if the spec means to prohibit `astype(complex_array, real_dtype):

```
Casting a complex floating-point array to a real-valued data type should not be permitted.
```

but at least `array_api_strict` allows it and emits the same warning is does numpy:

```
>>> import array_api_strict as xp
>>> xp.astype(xp.ones(3, dtype=xp.complex128), xp.float64)
/home/br/miniforge3/envs/array-api-tests/lib/python3.11/site-packages/array_api_strict/_data_type_functions.py:45: ComplexWarning: Casting complex values to real discards the imaginary part
  return Array._new(x._array.astype(dtype=dtype._np_dtype, copy=copy), device=device)
Array([1., 1., 1.], dtype=array_api_strict.float64)
```