### PR TITLE
Avoid calling hh.arrays with dtype=None for complex types

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -10,7 +10,7 @@ from typing import Any, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Un
 from hypothesis import assume, reject
 from hypothesis.strategies import (SearchStrategy, booleans, composite, floats,
                                    integers, just, lists, none, one_of,
-                                   sampled_from, shared, builds)
+                                   sampled_from, shared, builds, nothing)
 
 from . import _array_module as xp, api_version
 from . import array_helpers as ah
@@ -200,11 +200,11 @@ floating_dtypes = sampled_from(dh.all_float_dtypes)
 real_floating_dtypes = sampled_from(dh.real_float_dtypes)
 numeric_dtypes = sampled_from(dh.numeric_dtypes)
 # Note: this always returns complex dtypes, even if api_version < 2022.12
-complex_dtypes: SearchStrategy[Any] | None = sampled_from(dh.complex_dtypes) if dh.complex_dtypes else None
+complex_dtypes: SearchStrategy[Any] = sampled_from(dh.complex_dtypes) if dh.complex_dtypes else nothing()
 
 def all_floating_dtypes() -> SearchStrategy[DataType]:
     strat = floating_dtypes
-    if api_version >= "2022.12" and complex_dtypes is not None:
+    if api_version >= "2022.12" and not complex_dtypes.is_empty:
         strat |= complex_dtypes
     return strat
 

--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1062,6 +1062,7 @@ def test_clip(x, data):
 
 
 @pytest.mark.min_version("2022.12")
+@pytest.mark.skipif(hh.complex_dtypes.is_empty, reason="no complex data types to draw from")
 @given(hh.arrays(dtype=hh.complex_dtypes, shape=hh.shapes()))
 def test_conj(x):
     out = xp.conj(x)
@@ -1264,6 +1265,7 @@ def test_hypot(x1, x2):
 
 
 @pytest.mark.min_version("2022.12")
+@pytest.mark.skipif(hh.complex_dtypes.is_empty, reason="no complex data types to draw from")
 @given(hh.arrays(dtype=hh.complex_dtypes, shape=hh.shapes()))
 def test_imag(x):
     out = xp.imag(x)
@@ -1559,6 +1561,7 @@ def test_pow(ctx, data):
 
 
 @pytest.mark.min_version("2022.12")
+@pytest.mark.skipif(hh.complex_dtypes.is_empty, reason="no complex data types to draw from")
 @given(hh.arrays(dtype=hh.complex_dtypes, shape=hh.shapes()))
 def test_real(x):
     out = xp.real(x)


### PR DESCRIPTION
### Issue description

[ndonnx](https://github.com/Quantco/ndonnx) does not (yet) support complex data types. We signal that by setting `ARRAY_API_TESTS_SKIP_DTYPES="complex64,complex128"`. During the collection phase [`hypothesis_helpers.complex_dtypes`](https://github.com/data-apis/array-api-tests/blob/master/array_api_tests/hypothesis_helpers.py#L190) is set to `None`. However, downstream calls to `hypothesis_helpers.arrays` appear to not be able to handle `dtype=None` as an argument, ultimately leading to an error when looking up the data type such as:
```
________________ ERROR collecting array_api_tests/test_operators_and_elementwise_functions.py ________________________
api-coverage-tests/array_api_tests/test_operators_and_elementwise_functions.py:1066: in <module>
    @given(hh.arrays(dtype=hh.complex_dtypes, shape=hh.shapes()))
api-coverage-tests/array_api_tests/hypothesis_helpers.py:73: in arrays
    elements = from_dtype(dtype)
api-coverage-tests/array_api_tests/hypothesis_helpers.py:44: in from_dtype
    min_, max_ = dh.dtype_ranges[component_dtype]
api-coverage-tests/array_api_tests/dtype_helpers.py:85: in __getitem__
    raise KeyError(f"{key!r} not found")
E   KeyError: 'None not found'

```
Since data types are looked up using `__eq__` things appear to work if any of the data types compare equal to `None` which is the case for `numpy.dtype("float64")`, for example.

### Solution
This PR simply guards each affected tests (i.e. tests that work on `hypothesis_helpers.complex_dtypes`) with a respective if statement. This works just fine in practice for us, but I'm sure there is a better fix out there. I tried to set `complex_dtypes = ()`, which seems reasonable, but that lead to other errors.