### PR TITLE
Silence NonInteractiveExampleWarning in test_unary

### DIFF
--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -20,11 +20,12 @@ from dataclasses import dataclass, field
 from decimal import ROUND_HALF_EVEN, Decimal
 from enum import Enum, auto
 from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, Literal
-from warnings import warn
+from warnings import warn, filterwarnings, catch_warnings
 
 import pytest
 from hypothesis import given, note, settings, assume
 from hypothesis import strategies as st
+from hypothesis.errors import NonInteractiveExampleWarning
 
 from array_api_tests.typing import Array, DataType
 
@@ -1250,7 +1251,9 @@ assert len(iop_params) != 0
 
 @pytest.mark.parametrize("func_name, func, case", unary_params)
 def test_unary(func_name, func, case):
-    in_value = case.cond_from_dtype(xp.float64).example()
+    with catch_warnings():
+        filterwarnings('ignore', category=NonInteractiveExampleWarning)
+        in_value = case.cond_from_dtype(xp.float64).example()
     x = xp.asarray(in_value, dtype=xp.float64)
     out = func(x)
     out_value = float(out)


### PR DESCRIPTION
The `.example()` call leads to a number of warnings in the test suite:
```
/.../array-api-tests/array_api_tests/test_special_cases.py:1253: NonInteractiveExampleWarning: The `.example()` method is good for exploring strategies, but should only be used interactively.  We recommend using `@given` for tests - it performs better, saves and replays failures to avoid flakiness, and reports minimal examples. (strategy: from_dtype(float64, min_value=0.0, max_value=13_407_807_929_942_595_611_008_317_640_802_934_282_464_207_265_959_107_021_466_054_756_094_376_573_581_619_054_852_612_241_927_956_455_650_759_996_398_703_782_412_109_633_178_814_162_067_569_513_603_268_608, exclude_min=True))
    in_value = case.cond_from_dtype(xp.float64).example()
```
I don't see an easy way for `@given` to be used here, but silencing the warning will make it more friendly to downstream callers.
