### PR TITLE
ENH: add result_type_false: check the minimum promotion rules according to the spec

### DIFF
--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -204,3 +204,13 @@ def test_isdtype(dtype, kind):
 def test_result_type(dtypes):
     out = xp.result_type(*dtypes)
     ph.assert_dtype("result_type", in_dtype=dtypes, out_dtype=out, repr_name="out")
+
+
+@given(hh.mutually_non_promotable_dtypes(2))
+def test_result_type_false(dtypes):
+    """Test _very_ strict promotion rules according to the spec.
+       Conforming array libraries may extend the promotion rules, and
+       then they'll need to xfail this test.
+    """
+    with pytest.raises(TypeError):
+        xp.result_type(*dtypes)


### PR DESCRIPTION
https://data-apis.org/array-api/latest/API_specification/type_promotion.html#type-promotion specifies the minimum required promotion rules, and states that

> A conforming implementation of the array API standard may support additional type promotion rules beyond those described in this specification.

`array_api_strict` only allows this minimal promotion rules. So, add a test that promotions beyond this minimum set are not allowed. The test is mostly informational: an array provider may want signal that it allows extra promotion paths by xfailing the test.
