### PR TITLE
Ci lint py versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Python 3.8 is not available on ubuntu-latest images anymore.

