### PR TITLE
CI: update python versions on the lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
'ubuntu-latest' image does not have python==3.8 anymore