### PR TITLE
Do not require default dtype if no dtypes in kind supported 

### DIFF
--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -164,6 +164,11 @@ kind_to_dtypes = {
 }
 
 
+def available_kinds():
+    return {
+        kind for kind, dtypes in kind_to_dtypes.items() if dtypes
+    }
+
 def is_int_dtype(dtype):
     return dtype in all_int_dtypes
 

--- a/array_api_tests/test_inspection_functions.py
+++ b/array_api_tests/test_inspection_functions.py
@@ -1,5 +1,6 @@
 import pytest
 from hypothesis import given, strategies as st
+from array_api_tests.dtype_helpers import available_kinds
 
 from . import xp
 
@@ -16,7 +17,8 @@ def test_array_namespace_info():
 
     default_dtypes = out.default_dtypes()
     assert isinstance(default_dtypes, dict)
-    assert {"real floating", "complex floating", "integral", "indexing"}.issubset(set(default_dtypes.keys()))
+    expected_subset = {"real floating", "complex floating", "integral"} & available_kinds() | {"indexing"}
+    assert expected_subset.issubset(set(default_dtypes.keys()))
 
     devices = out.devices()
     assert isinstance(devices, list)


### PR DESCRIPTION
The [description](https://data-apis.org/array-api/2023.12/API_specification/generated/array_api.info.default_dtypes.html#array_api.info.default_dtypes) of `__array_namespace_info__`'s `default_dtypes` method requires that you return a default dtype for all the keys specified.

The test suite here allows you to skip certain dtypes using the `ARRAY_API_TESTS_SKIP_DTYPES` environment variable. This means that it's possible to omit all the dtypes for a given kind.  We use this in ndonnx to skip all complex dtypes since we're not able to support them at this time. In such a context, a default for `"complex floating"` doesn't make much sense.

I would like to only check the `default_dtypes` keys are present for kinds where we haven't skipped all the relevant dtypes. An alternative could be to make the value of the dictionary an optional `dtype | None` in a future version of the standard. I'd be happy with either option.