### PR TITLE
test indexing with arrays

### DIFF
--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -287,9 +287,9 @@ def test_getitem_arrays_and_ints(shape, data):
 
     # XXX: how to properly check
     import numpy as np
-    x_np = np.asarray(x)
-    out_np = np.asarray(out)
-    key_np = tuple(k if isinstance(k, int) else np.asarray(k) for k in key)
+    x_np = np.asarray(x.get())
+    out_np = np.asarray(out.get())
+    key_np = tuple(k if isinstance(k, int) else np.asarray(k.get()) for k in key)
 
     np.testing.assert_equal(out_np, x_np[key_np])
 

--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -285,16 +285,11 @@ def test_getitem_arrays_and_ints(shape, data):
     key = tuple(key)
     out = x[key]
 
-    if sum(arr_index) > 1:
-        breakpoint()
-
     # XXX: how to properly check
     import numpy as np
     x_np = np.asarray(x)
     out_np = np.asarray(out)
     key_np = tuple(k if isinstance(k, int) else np.asarray(k) for k in key)
-
- #   print(f"{x.shape = } {out.shape = } -- {[k if isinstance(k, int) else k.shape for k in key]}")
 
     np.testing.assert_equal(out_np, x_np[key_np])
 

--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -287,9 +287,9 @@ def test_getitem_arrays_and_ints(shape, data):
 
     # XXX: how to properly check
     import numpy as np
-    x_np = np.asarray(x.get())
-    out_np = np.asarray(out.get())
-    key_np = tuple(k if isinstance(k, int) else np.asarray(k.get()) for k in key)
+    x_np = np.asarray(x)
+    out_np = np.asarray(out)
+    key_np = tuple(k if isinstance(k, int) else np.asarray(k) for k in key)
 
     np.testing.assert_equal(out_np, x_np[key_np])
 


### PR DESCRIPTION
cross-ref https://github.com/data-apis/array-api/issues/669 : test indexing arrays objects with a mix of integers and arrays.

-  I'm not sure how to properly assert correctness here. I currently just check that results agree with numpy, which is not right. Maybe there's something in the `ndindex`  library that would help.  Could you weight in @asmeurer?
- Do we need to test `__setitem__` in addition to getitem?

As a data point, the current (hacky) test seems to pass locally with numpy (unsurprisingly), pytorch and jax.numpy.
EDIT: also passes locally with array-api-strict, patched via https://github.com/data-apis/array-api-strict/compare/main...ev-br:array_indexing?expand=1 (the patch certainly allows way too much, is for demo purposes only).

<details><summary> A CLI incantation to run tests locally</summary>

```
$ ARRAY_API_TESTS_MODULE=torch pytest array_api_tests/test_array_object.py::test_getitem_arrays_and_ints -vs --max-examples=2000 --pdb
```

</details> 

cc @kgryte for viz