### PR TITLE
Test fancy indexing with integers and index arrays

### DIFF
--- a/array_api_tests/test_array_object.py
+++ b/array_api_tests/test_array_object.py
@@ -242,6 +242,76 @@ def test_setitem_masking(shape, data):
             )
 
 
+@pytest.mark.min_version("2024.12")
+@pytest.mark.unvectorized
+@given(shape=hh.shapes(min_dims=2), data=st.data())
+def test_getitem_arrays_and_ints_1(shape, data):
+    # min_dims=2 : test multidim `x` arrays
+    # index arrays are all 1D
+    _test_getitem_arrays_and_ints_1D(shape, data)
+
+
+@pytest.mark.min_version("2024.12")
+@pytest.mark.unvectorized
+@given(shape=hh.shapes(min_dims=1), data=st.data())
+def test_getitem_arrays_and_ints_2(shape, data):
+    # min_dims=1 : favor 1D `x` arrays
+    # index arrays are all 1D
+    _test_getitem_arrays_and_ints_1D(shape, data)
+
+
+def _test_getitem_arrays_and_ints_1D(shape, data):
+    assume((len(shape) > 0) and all(sh > 0 for sh in shape))
+
+    dtype = xp.int32
+    obj = data.draw(scalar_objects(dtype, shape), label="obj")
+    x = xp.asarray(obj, dtype=dtype)
+
+    # draw a mix of ints and index arrays
+    arr_index = [data.draw(st.booleans()) for _ in range(len(shape))]
+    assume(sum(arr_index) > 0)
+
+    # draw shapes for index arrays: NB max_dims=1 ==> 1D indexing arrays ONLY
+    if sum(arr_index) > 0:
+        index_shapes = data.draw(
+            hh.mutually_broadcastable_shapes(
+                sum(arr_index), min_dims=1, max_dims=1, min_side=1
+            )
+        )
+        index_shapes = list(index_shapes)
+
+    # prepare the indexing tuple, a mix of integer indices and index arrays
+    key = []
+    for i,typ in enumerate(arr_index):
+        if typ:
+            # draw an array index
+            this_idx = data.draw(
+                xps.arrays(
+                    dtype,
+                    shape=index_shapes.pop(),
+                    elements=st.integers(0, shape[i]-1)
+                )
+            )
+            key.append(this_idx)
+
+        else:
+            # draw an integer
+            key.append(data.draw(st.integers(-shape[i], shape[i]-1)))
+
+    # print(f"??? {x.shape = } {key = }")
+
+    key = tuple(key)
+    out = x[key]
+
+    arrays = [xp.asarray(k) for k in key]
+    bcast_shape = sh.broadcast_shapes(*[arr.shape for arr in arrays])
+    bcast_key = [xp.broadcast_to(arr, bcast_shape) for arr in arrays]
+
+    for idx in sh.ndindex(bcast_shape):
+        tpl = tuple(k[idx] for k in bcast_key)
+        assert out[idx] == x[tpl], f"failing at {idx = } w/ {key = }"
+
+
 def make_scalar_casting_param(
     method_name: str, dtype: DataType, stype: ScalarType
 ) -> Param:


### PR DESCRIPTION
cross-ref https://github.com/data-apis/array-api/issues/669 : test indexing arrays objects with a mix of integers and arrays.

Locally, this test passes with torch, cupy, jax.numpy and numpy, and smokes multiple issues with `dask.array`  fancy indexing. To run it locally, remove the `@pytest.mark.min_version("2024.12")` decorators

TODO:
-  [x] rerun with `2024.12` and `array-api-strict >= 2.3.0`, when available.