### PR TITLE
MAINT: always skip test_nan_propagation[cumulative_prod]

### DIFF
--- a/array-api-strict-skips.txt
+++ b/array-api-strict-skips.txt
@@ -7,7 +7,7 @@ array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -0 and x2_i > 0
 # (https://github.com/data-apis/array-api-tests/issues/168)
 array_api_tests/test_statistical_functions.py::test_sum
 
-# 2024.12 new failures, investigate
+# Stubs have a comment: (**note**: libraries may return ``NaN`` to match Python behavior.); Apparently, all libraries do just that
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
@@ -26,7 +26,4 @@ array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity 
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
-
-# 2024.12 new failure, ndim=0 not allowed in cumulative_prod
-array_api_tests/test_special_cases.py::test_nan_propagation[cumulative_prod]
 

--- a/array_api_tests/test_special_cases.py
+++ b/array_api_tests/test_special_cases.py
@@ -1332,7 +1332,7 @@ def test_empty_arrays(func_name, expected):  # TODO: parse docstrings to get exp
 
 @pytest.mark.parametrize(
     "func_name", [f.__name__ for f in category_to_funcs["statistical"]
-                  if f.__name__ != 'cumulative_sum']
+                  if f.__name__ not in ['cumulative_sum', 'cumulative_prod']]
 )
 @given(
     x=hh.arrays(dtype=hh.real_floating_dtypes, shape=hh.shapes(min_side=1)),


### PR DESCRIPTION
`cumulative_sum` is excluded, and so should be `cumulative_prod`

This makes sense: a single nan in a middle of an array "taints" all subsequent values to be nan