### PR TITLE
ENH: improve testing of `result_type`

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -10,7 +10,11 @@ from typing import Any, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Un
 from hypothesis import assume, reject
 from hypothesis.strategies import (SearchStrategy, booleans, composite, floats,
                                    integers, complex_numbers, just, lists, none, one_of,
+<<<<<<< HEAD
                                    sampled_from, shared, builds, nothing)
+=======
+                                   sampled_from, shared, builds, nothing, permutations)
+>>>>>>> ENH: add a test that result_type does not depend on the order of arguments
 
 from . import _array_module as xp, api_version
 from . import array_helpers as ah
@@ -146,6 +150,13 @@ def mutually_promotable_dtypes(
                 lambda l: not (xp.uint64 in l and any(d in dh.int_dtypes for d in l))
             )
     return one_of(strats).map(tuple)
+
+
+@composite
+def pair_of_mutually_promotable_dtypes(draw, max_size=2, *, dtypes=dh.all_dtypes):
+    sample = draw(mutually_promotable_dtypes( max_size, dtypes=dtypes))
+    permuted = draw(permutations(sample))
+    return sample, permuted
 
 
 class OnewayPromotableDtypes(NamedTuple):

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -10,11 +10,7 @@ from typing import Any, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Un
 from hypothesis import assume, reject
 from hypothesis.strategies import (SearchStrategy, booleans, composite, floats,
                                    integers, complex_numbers, just, lists, none, one_of,
-<<<<<<< HEAD
-                                   sampled_from, shared, builds, nothing)
-=======
                                    sampled_from, shared, builds, nothing, permutations)
->>>>>>> ENH: add a test that result_type does not depend on the order of arguments
 
 from . import _array_module as xp, api_version
 from . import array_helpers as ah

--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -156,7 +156,7 @@ def mutually_promotable_dtypes(
 def pair_of_mutually_promotable_dtypes(draw, max_size=2, *, dtypes=dh.all_dtypes):
     sample = draw(mutually_promotable_dtypes( max_size, dtypes=dtypes))
     permuted = draw(permutations(sample))
-    return sample, permuted
+    return sample, tuple(permuted)
 
 
 class OnewayPromotableDtypes(NamedTuple):

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -208,7 +208,17 @@ def test_isdtype(dtype, kind):
     assert out == expected, f"{out=}, but should be {expected} [isdtype()]"
 
 
-@given(hh.mutually_promotable_dtypes(None))
-def test_result_type(dtypes):
-    out = xp.result_type(*dtypes)
-    ph.assert_dtype("result_type", in_dtype=dtypes, out_dtype=out, repr_name="out")
+class TestResultType:
+    @given(dtypes=hh.mutually_promotable_dtypes(None))
+    def test_result_type(self, dtypes):
+        out = xp.result_type(*dtypes)
+        ph.assert_dtype("result_type", in_dtype=dtypes, out_dtype=out, repr_name="out")
+
+    @given(pair=hh.pair_of_mutually_promotable_dtypes(None))
+    def test_shuffled(self, pair):
+        """Test that result_type is insensitive to the order of arguments."""
+        s1, s2 = pair
+        out1 = xp.result_type(*s1)
+        out2 = xp.result_type(*s2)
+        assert out1 == out2
+

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -222,3 +222,11 @@ class TestResultType:
         out2 = xp.result_type(*s2)
         assert out1 == out2
 
+    @given(pair=hh.pair_of_mutually_promotable_dtypes(2), data=st.data())
+    def test_arrays_and_dtypes(self, pair, data):
+        s1, s2 = pair
+        a2 = tuple(xp.empty(1, dtype=dt) for dt in s2)
+        a_and_dt = data.draw(st.permutations(s1 + a2))
+        out = xp.result_type(*a_and_dt)
+        ph.assert_dtype("result_type", in_dtype=s1+s2, out_dtype=out, repr_name="out")
+


### PR DESCRIPTION
cross-ref https://github.com/scipy/scipy/pull/22695

- [x] add a test that result_type does not depend on the order of arguments
- [x] add a test with arrays and dtypes
- [x] add a test with arrays, dtypes and scalars
- [ ] <s>check if we can test with f64 being the pytorch default dtype</s>: tracked in https://github.com/data-apis/array-api-compat/issues/278