### PR TITLE
Tighten tests on `iinfo`/`finfo`

### DIFF
--- a/array-api-strict-skips.txt
+++ b/array-api-strict-skips.txt
@@ -27,3 +27,8 @@ array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity 
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
 
+# FIXME needs array-api-strict >=2.3.2
+array_api_tests/test_data_type_functions.py::test_finfo
+array_api_tests/test_data_type_functions.py::test_finfo_dtype
+array_api_tests/test_data_type_functions.py::test_iinfo
+array_api_tests/test_data_type_functions.py::test_iinfo_dtype

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -147,62 +147,58 @@ def test_can_cast(_from, to):
         assert out == expected, f"{out=}, but should be {expected} {f_func}"
 
 
-@pytest.mark.parametrize("arg_type", ["dtype", "array"])
 @pytest.mark.parametrize("dtype", dh.real_float_dtypes + dh.complex_dtypes)
-def test_finfo(dtype, arg_type):
-    arg = xp.asarray(1, dtype=dtype) if arg_type == "array" else dtype
-    out = xp.finfo(arg)
+def test_finfo(dtype):
+    for arg in (
+        dtype,
+        xp.asarray(1, dtype=dtype),
+        # np.float64 and np.asarray(1, dtype=np.float64).dtype are different
+        xp.asarray(1, dtype=dtype).dtype,
+    ):
+        out = xp.finfo(arg)
+        assert isinstance(out.bits, int)
+        assert isinstance(out.eps, float)
+        assert isinstance(out.max, float)
+        assert isinstance(out.min, float)
+        assert isinstance(out.smallest_normal, float)
 
-    f_func = f"[finfo({dh.dtype_to_name[dtype]})]"
-    for attr, stype in [
-        ("bits", int),
-        ("eps", float),
-        ("max", float),
-        ("min", float),
-        ("smallest_normal", float),
-    ]:
-        assert hasattr(out, attr), f"out has no attribute '{attr}' {f_func}"
-        value = getattr(out, attr)
-        assert isinstance(
-            value, stype
-        ), f"type(out.{attr})={type(value)!r}, but should be {stype.__name__} {f_func}"
-    assert hasattr(out, "dtype"), f"out has no attribute 'dtype' {f_func}"
 
-    assert isinstance(out.bits, int)
-    assert isinstance(out.eps, float)
-    assert isinstance(out.max, float)
-    assert isinstance(out.min, float)
-    assert isinstance(out.smallest_normal, float)
+@pytest.mark.min_version("2022.12")
+@pytest.mark.parametrize("dtype", dh.real_float_dtypes + dh.complex_dtypes)
+def test_finfo_dtype(dtype):
+    out = xp.finfo(dtype)
+
     if dtype == xp.complex64:
         assert out.dtype == xp.float32
     elif dtype == xp.complex128:
         assert out.dtype == xp.float64
     else:
         assert out.dtype == dtype
+
     # Guard vs. numpy.dtype.__eq__ lax comparison
     assert not isinstance(out.dtype, str)
     assert out.dtype is not float
     assert out.dtype is not complex
 
 
-@pytest.mark.parametrize("arg_type", ["dtype", "array"])
 @pytest.mark.parametrize("dtype", dh.int_dtypes + dh.uint_dtypes)
-def test_iinfo(dtype, arg_type):
-    arg = xp.asarray(1, dtype=dtype) if arg_type == "array" else dtype
-    out = xp.iinfo(arg)
+def test_iinfo(dtype):
+    for arg in (
+        dtype,
+        xp.asarray(1, dtype=dtype),
+        # np.int64 and np.asarray(1, dtype=np.int64).dtype are different
+        xp.asarray(1, dtype=dtype).dtype,
+    ):
+        out = xp.iinfo(arg)
+        assert isinstance(out.bits, int)
+        assert isinstance(out.max, int)
+        assert isinstance(out.min, int)
 
-    f_func = f"[iinfo({dh.dtype_to_name[dtype]})]"
-    for attr in ["bits", "max", "min"]:
-        assert hasattr(out, attr), f"out has no attribute '{attr}' {f_func}"
-        value = getattr(out, attr)
-        assert isinstance(
-            value, int
-        ), f"type(out.{attr})={type(value)!r}, but should be int {f_func}"
-    assert hasattr(out, "dtype"), f"out has no attribute 'dtype' {f_func}"
 
-    assert isinstance(out.bits, int)
-    assert isinstance(out.max, int)
-    assert isinstance(out.min, int)
+@pytest.mark.min_version("2022.12")
+@pytest.mark.parametrize("dtype", dh.int_dtypes + dh.uint_dtypes)
+def test_iinfo_dtype(dtype):
+    out = xp.iinfo(dtype)
     assert out.dtype == dtype
     # Guard vs. numpy.dtype.__eq__ lax comparison
     assert not isinstance(out.dtype, str)

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -147,9 +147,12 @@ def test_can_cast(_from, to):
         assert out == expected, f"{out=}, but should be {expected} {f_func}"
 
 
-@pytest.mark.parametrize("dtype", dh.real_float_dtypes)
-def test_finfo(dtype):
-    out = xp.finfo(dtype)
+@pytest.mark.parametrize("arg_type", ["dtype", "array"])
+@pytest.mark.parametrize("dtype", dh.real_float_dtypes + dh.complex_dtypes)
+def test_finfo(dtype, arg_type):
+    arg = xp.asarray(1, dtype=dtype) if arg_type == "array" else dtype
+    out = xp.finfo(arg)
+
     f_func = f"[finfo({dh.dtype_to_name[dtype]})]"
     for attr, stype in [
         ("bits", int),
@@ -164,12 +167,30 @@ def test_finfo(dtype):
             value, stype
         ), f"type(out.{attr})={type(value)!r}, but should be {stype.__name__} {f_func}"
     assert hasattr(out, "dtype"), f"out has no attribute 'dtype' {f_func}"
-    # TODO: test values
+
+    assert isinstance(out.bits, int)
+    assert isinstance(out.eps, float)
+    assert isinstance(out.max, float)
+    assert isinstance(out.min, float)
+    assert isinstance(out.smallest_normal, float)
+    if dtype == xp.complex64:
+        assert out.dtype == xp.float32
+    elif dtype == xp.complex128:
+        assert out.dtype == xp.float64
+    else:
+        assert out.dtype == dtype
+    # Guard vs. numpy.dtype.__eq__ lax comparison
+    assert not isinstance(out.dtype, str)
+    assert out.dtype is not float
+    assert out.dtype is not complex
 
 
-@pytest.mark.parametrize("dtype", dh.int_dtypes)
-def test_iinfo(dtype):
-    out = xp.iinfo(dtype)
+@pytest.mark.parametrize("arg_type", ["dtype", "array"])
+@pytest.mark.parametrize("dtype", dh.int_dtypes + dh.uint_dtypes)
+def test_iinfo(dtype, arg_type):
+    arg = xp.asarray(1, dtype=dtype) if arg_type == "array" else dtype
+    out = xp.iinfo(arg)
+
     f_func = f"[iinfo({dh.dtype_to_name[dtype]})]"
     for attr in ["bits", "max", "min"]:
         assert hasattr(out, attr), f"out has no attribute '{attr}' {f_func}"
@@ -178,7 +199,14 @@ def test_iinfo(dtype):
             value, int
         ), f"type(out.{attr})={type(value)!r}, but should be int {f_func}"
     assert hasattr(out, "dtype"), f"out has no attribute 'dtype' {f_func}"
-    # TODO: test values
+
+    assert isinstance(out.bits, int)
+    assert isinstance(out.max, int)
+    assert isinstance(out.min, int)
+    assert out.dtype == dtype
+    # Guard vs. numpy.dtype.__eq__ lax comparison
+    assert not isinstance(out.dtype, str)
+    assert out.dtype is not int
 
 
 def atomic_kinds() -> st.SearchStrategy[Union[DataType, str]]:


### PR DESCRIPTION
- test iinfo/finfo vs array input
- test output object

# NOTE
This makes array-api-compat explode. Needs prerequisite PR https://github.com/data-apis/array-api-compat/pull/294
CI will fail here until the next array-api-strict release, when it will pick up https://github.com/data-apis/array-api-strict/pull/135

```
array_api_strict git tip
================================================================
(all green)

array_api_strict 2.3.1 (CI below)
================================================================
- array inputs fail (https://github.com/data-apis/array-api-strict/pull/143)
- dtype is a numpy dtype (https://github.com/data-apis/array-api-strict/pull/135)

array_api_compat.numpy (array-api-compat git tip, numpy 2.2)
================================================================
FAILED array_api_tests/test_data_type_functions.py::test_finfo[float32-dtype] - AssertionError: type(out.eps)=<class 'numpy.float32'>, but should be float [finfo(float32)]
FAILED array_api_tests/test_data_type_functions.py::test_finfo[complex64-dtype] - AssertionError: type(out.eps)=<class 'numpy.float32'>, but should be float [finfo(complex64)]
FAILED array_api_tests/test_data_type_functions.py::test_finfo[*-array] - ValueError: data type <class 'numpy.object_'> not inexact
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[*-array] - ValueError: Invalid integer data type 'O'.

array_api_compat.dask.array (array-api-compat git tip)
================================================================
FAILED array_api_tests/test_data_type_functions.py::test_finfo[float32-*] - AssertionError: type(out.eps)=<class 'numpy.float32'>, but should be float [finfo(float32)]
FAILED array_api_tests/test_data_type_functions.py::test_finfo[complex64-*] - AssertionError: type(out.eps)=<class 'numpy.float32'>, but should be float [finfo(complex64)]

array_api_compat.cupy (array-api-compat git tip)
================================================================
FAILED array_api_tests/test_data_type_functions.py::test_finfo[float32-*] - AssertionError: type(out.eps)=<class 'numpy.float32'>, but should be float [finfo(float32)]
FAILED array_api_tests/test_data_type_functions.py::test_finfo[complex64-*] - AssertionError: type(out.eps)=<class 'numpy.float32'>, but should be float [finfo(complex64)]

array_api_compat.torch (array-api-compat git tip)
================================================================
FAILED array_api_tests/test_data_type_functions.py::test_finfo[dtype0-dtype] - AssertionError: assert 'float32' == torch.float32
FAILED array_api_tests/test_data_type_functions.py::test_finfo[dtype1-dtype] - AssertionError: assert 'float64' == torch.float64
FAILED array_api_tests/test_data_type_functions.py::test_finfo[dtype2-dtype] - AssertionError: assert 'float32' == torch.float32
FAILED array_api_tests/test_data_type_functions.py::test_finfo[dtype3-dtype] - AssertionError: assert 'float64' == torch.float64
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype0-dtype] - AssertionError: assert 'int8' == torch.int8
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype1-dtype] - AssertionError: assert 'int16' == torch.int16
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype2-dtype] - AssertionError: assert 'int32' == torch.int32
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype3-dtype] - AssertionError: assert 'int64' == torch.int64
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype4-dtype] - AssertionError: assert 'uint8' == torch.uint8
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype5-dtype] - AssertionError: assert 'uint16' == torch.uint16
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype6-dtype] - AssertionError: assert 'uint32' == torch.uint32
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[dtype7-dtype] - AssertionError: assert 'uint64' == torch.uint64
FAILED array_api_tests/test_data_type_functions.py::test_iinfo[*-array] - TypeError: iinfo(): argument 'type' (position 1) must be torch.dtype, not Tensor
```