### PR TITLE
test_clip: make sure `min` and `max` have the same dtype as `x`

### DIFF
--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -987,17 +987,15 @@ def test_clip(x, data):
                                                                 base_shape=x.shape),
                                 label="min.shape, max.shape")
 
-    dtypes = hh.real_floating_dtypes if dh.is_float_dtype(x.dtype) else hh.int_dtypes
-
     min = data.draw(st.one_of(
         st.none(),
         hh.scalars(dtypes=st.just(x.dtype)),
-        hh.arrays(dtype=dtypes, shape=shape1),
+        hh.arrays(dtype=st.just(x.dtype), shape=shape1),
     ), label="min")
     max = data.draw(st.one_of(
         st.none(),
         hh.scalars(dtypes=st.just(x.dtype)),
-        hh.arrays(dtype=dtypes, shape=shape2),
+        hh.arrays(dtype=st.just(x.dtype), shape=shape2),
     ), label="max")
 
     # min > max is undefined (but allow nans)


### PR DESCRIPTION
closes gh-359, closes gh-339

Per the spec: 'should have the same dtype as x': https://data-apis.org/array-api/latest/API_specification/generated/array_api.clip.html

The spec is not very clear on whether `min` and `max` can be `int` scalars for a real-valued `x` array, should probably clarify in the spec:

- On one hand, _Hence, if x and either min or max have different data type kinds (e.g., integer versus floating-point), behavior is unspecified and thus implementation-dependent._
- On the other hand, https://data-apis.org/array-api/latest/API_specification/type_promotion.html#type-promotion, allows int->float->float32
