### PR TITLE
MAINT: simplify running tests with SKIP_DTYPES=float64

### DIFF
--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -24,7 +24,12 @@ def float32(n: Union[int, float]) -> float:
 
 
 def _float_match_complex(complex_dtype):
-    return xp.float32 if complex_dtype == xp.complex64 else xp.float64
+    if complex_dtype == xp.complex64:
+        return xp.float32
+    elif complex_dtype == xp.complex128:
+        return xp.float64
+    else:
+        return dh.default_float
 
 
 @given(


### PR DESCRIPTION
With this patch,

```
$ ARRAY_API_TESTS_MODULE=array_api_compat.torch ARRAY_API_TESTS_SKIP_DTYPES=uint16,uint32,uint64,float64,complex128 pytest array_api_tests/  --skips-file=../array-api-compat/torch-xfails.txt -v
```

is passing modulo some minor failures in test_signatures.py