### PR TITLE
Avoid undefined behavior in asarray with very large intergers

### DIFF
--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -1000,8 +1000,8 @@ def test_clip(x, data):
         hh.arrays(dtype=st.just(x.dtype), shape=shape2),
     ), label="max")
 
-    # min > max is undefined (but allow nans)
-    assume(min is None or max is None or not xp.any(ah.less(xp.asarray(max), xp.asarray(min))))
+    # Note1: min > max is undefined (but allow nans)
+    assume(min is None or max is None or not xp.any(ah.less(xp.asarray(max, dtype=x.dtype), xp.asarray(min, dtype=x.dtype))))
 
     kw = data.draw(
         hh.specified_kwargs(


### PR DESCRIPTION
The `min` and `max` values are drawn specifically for their dtypes. This means that they may assume values that overflow the default integer data type. This is [explicitly](https://data-apis.org/array-api/draft/API_specification/generated/array_api.asarray.html#asarray) undefined behavior in the standard. This change avoids this UB by passing the `dtype` parameter to `asarray` where appropriate. 