### PR TITLE
POC: start adding "repro snippets" for failed assertions

### DIFF
--- a/array_api_tests/pytest_helpers.py
+++ b/array_api_tests/pytest_helpers.py
@@ -599,3 +599,7 @@ def assert_array_elements(
             at_expected = expected[idx]
             msg = msg_template.format(sh.fmt_idx(out_repr, idx), at_out, at_expected)
             assert at_out == at_expected, msg
+
+
+def format_snippet(s: str):
+    return f"\n{'='*10} FAILING CODE SNIPPET:\n{s}\n{'='*20}\n"

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -160,13 +160,17 @@ def test_finfo(dtype):
         # np.float64 and np.asarray(1, dtype=np.float64).dtype are different
         xp.asarray(1, dtype=dtype).dtype,
     ):
-        out = xp.finfo(arg)
-        assert isinstance(out.bits, int)
-        assert isinstance(out.eps, float)
-        assert isinstance(out.max, float)
-        assert isinstance(out.min, float)
-        assert isinstance(out.smallest_normal, float)
-
+        repro_snippet = ph.format_snippet(f"xp.finfo({arg})")
+        try:
+            out = xp.finfo(arg)
+            assert isinstance(out.bits, int)
+            assert isinstance(out.eps, float)
+            assert isinstance(out.max, float)
+            assert isinstance(out.min, float)
+            assert isinstance(out.smallest_normal, float)
+        except Exception as exc:
+            exc.add_note(repro_snippet)
+            raise
 
 @pytest.mark.min_version("2022.12")
 @pytest.mark.parametrize("dtype", dh.real_float_dtypes + dh.complex_dtypes)

--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -313,37 +313,45 @@ def test_repeat(x, kw, data):
 
     assume(n_repititions <= hh.SQRT_MAX_ARRAY_SIZE)
 
-    out = xp.repeat(x, repeats, **kw)
-    ph.assert_dtype("repeat", in_dtype=x.dtype, out_dtype=out.dtype)
-    if axis is None:
-        expected_shape = (n_repititions,)
-    else:
-        expected_shape = list(shape)
-        expected_shape[axis] = n_repititions
-        expected_shape = tuple(expected_shape)
-    ph.assert_shape("repeat", out_shape=out.shape, expected=expected_shape)
+    repro_snippet = ph.format_snippet(f"xp.repeat({x!r},{repeats!r}, **kw) with {kw=}")
+    try:
+        out = xp.repeat(x, repeats, **kw)
 
-    # Test values
+        ph.assert_dtype("repeat", in_dtype=x.dtype, out_dtype=out.dtype)
+        if axis is None:
+            expected_shape = (n_repititions,)
+        else:
+            expected_shape = list(shape)
+            expected_shape[axis] = n_repititions
+            expected_shape = tuple(expected_shape)
+        ph.assert_shape("repeat", out_shape=out.shape, expected=expected_shape)
 
-    if isinstance(repeats, int):
-        repeats_array = xp.full(size, repeats, dtype=xp.int32)
-    else:
-        repeats_array = repeats
+        # Test values
 
-    if kw.get("axis") is None:
-        x = xp.reshape(x, (-1,))
-        axis = 0
+        if isinstance(repeats, int):
+            repeats_array = xp.full(size, repeats, dtype=xp.int32)
+        else:
+            repeats_array = repeats
 
-    for idx, in sh.iter_indices(x.shape, skip_axes=axis):
-        x_slice = x[idx]
-        out_slice = out[idx]
-        start = 0
-        for i, count in enumerate(repeats_array):
-            end = start + count
-            ph.assert_array_elements("repeat", out=out_slice[start:end],
-                                     expected=xp.full((count,), x_slice[i], dtype=x.dtype),
-                                     kw=kw)
-            start = end
+        if kw.get("axis") is None:
+            x = xp.reshape(x, (-1,))
+            axis = 0
+
+        for idx, in sh.iter_indices(x.shape, skip_axes=axis):
+            x_slice = x[idx]
+            out_slice = out[idx]
+            start = 0
+            for i, count in enumerate(repeats_array):
+                end = start + count
+                ph.assert_array_elements("repeat", out=out_slice[start:end],
+                                         expected=xp.full((count,), x_slice[i], dtype=x.dtype),
+                                         kw=kw)
+                start = end
+
+    except Exception as exc:
+        exc.add_note(repro_snippet)
+        raise
+
 
 reshape_shape = st.shared(hh.shapes(), key="reshape_shape")
 


### PR DESCRIPTION
It is not always easy to tell what exactly failed with hypothesis (gh-379). Thus add a failing snippet to the exceptions' output.

With this PR, the OP example from gh-379 preserves whatever output pytest and hypothesis generated, and adds an explicit incantation that triggered the error:

```
$ ARRAY_API_TESTS_MODULE=array_api_compat.numpy pytest array_api_tests/test_manipulation_functions.py::test_repeat

... snip ...

array_api_tests/test_manipulation_functions.py:288: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
array_api_tests/test_manipulation_functions.py:318: in test_repeat
    out = xp.repeat(x, repeats, **kw)
../../miniforge3/envs/array-api/lib/python3.12/site-packages/numpy/_core/fromnumeric.py:506: in repeat
    return _wrapfunc(a, 'repeat', repeats, axis=axis)
../../miniforge3/envs/array-api/lib/python3.12/site-packages/numpy/_core/fromnumeric.py:66: in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

obj = array([], dtype=bool), method = 'repeat', args = (array([], dtype=uint64),)
kwds = {'axis': None}
conv = <numpy._core._multiarray_umath._array_converter object at 0x7fd5f2252c10>
arr = array([], dtype=bool)

    def _wrapit(obj, method, *args, **kwds):
        conv = _array_converter(obj)
        # As this already tried the method, subok is maybe quite reasonable here
        # but this follows what was done before. TODO: revisit this.
        arr, = conv.as_arrays(subok=False)
>       result = getattr(arr, method)(*args, **kwds)
E       TypeError: Cannot cast array data from dtype('uint64') to dtype('int64') according to the rule 'safe'
E       
E       ========== FAILING CODE SNIPPET:
E       xp.repeat(array([], dtype=bool),array([], dtype=uint64), **kw) with kw={}
E       ====================
E       
E       Falsifying example: test_repeat(
E           x=array([], dtype=bool),
E           kw={},
E           data=data(...),
E       )
E       Draw 1 (repeats): array([], dtype=uint64)

../../miniforge3/envs/array-api/lib/python3.12/site-packages/numpy/_core/fromnumeric.py:46: TypeError
=============================== short test summary info ================================
FAILED array_api_tests/test_manipulation_functions.py::test_repeat - TypeError: Cannot cast array data from dtype('uint64') to dtype('int64') according ...
================================== 1 failed in 0.24s ===================================
```

The approach here is a bit manual, and I don't see a generic way to make it less so.