### PR TITLE
Pass `tuple[int]` instead of `tuple[Array]` as shape to `xp.full`

### DIFF
--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -341,7 +341,7 @@ def test_repeat(x, kw, data):
         for i, count in enumerate(repeats_array):
             end = start + count
             ph.assert_array_elements("repeat", out=out_slice[start:end],
-                                     expected=xp.full((count,), x_slice[i], dtype=x.dtype),
+                                     expected=xp.full((int(count),), x_slice[i], dtype=x.dtype),
                                      kw=kw)
             start = end
 


### PR DESCRIPTION
The existing test for `repeat` relies on `full` being able to consume a tupel of scalar `Array` objects. The latter is not part of the [standard](https://data-apis.org/array-api/draft/API_specification/generated/array_api.full.html#full). A simple call to Python's `int` saves the day.
