### PR TITLE
FIX: larger inputs for sorting tests - to test sorts stability

### DIFF
--- a/array_api_tests/test_sorting_functions.py
+++ b/array_api_tests/test_sorting_functions.py
@@ -34,6 +34,8 @@ def assert_scalar_in_set(
     x=hh.arrays(
         dtype=hh.real_dtypes,
         shape=hh.shapes(min_dims=1, min_side=1, max_side=50),
+        # argsort needs to be tested on big enough arrays, hence we set `max_side=50`
+        # see https://github.com/data-apis/array-api-tests/issues/389
         elements={"allow_nan": False},
     ),
     data=st.data(),
@@ -95,6 +97,8 @@ def test_argsort(x, data):
     x=hh.arrays(
         dtype=hh.real_dtypes,
         shape=hh.shapes(min_dims=1, min_side=1, max_side=50),
+        # sort needs to be tested on big enough arrays, hence we set `max_side=50`
+        # see https://github.com/data-apis/array-api-tests/issues/389
         elements={"allow_nan": False},
     ),
     data=st.data(),


### PR DESCRIPTION
Fixes: https://github.com/data-apis/array-api-tests/issues/389

To test sort stability of array libraries, you usually need arrays of more than 16 elements (because for less than 16, libs often default to an inherently stable sort, even for unstable algorithms).

Because of this was not tested properly, a gap in array-api-compat was not detected by this test suite. See issue https://github.com/data-apis/array-api-compat/issues/354. You can try running:
```bash
ARRAY_API_TESTS_VERSION="2024.12" ARRAY_API_TESTS_MODULE=array_api_compat.torch pytest array_api_tests/test_sorting_functions.py
```
with this branch of `array-api-tests` to see it indeed fails.