### PR TITLE
ENH: add tests for `eig` and `eigvals`

### DIFF
--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -231,7 +231,6 @@ def real_dtype_for(dtyp):
     return real_dtype
 
 
-
 def _make_dtype_mapping_from_names(mapping: Dict[str, Any]) -> EqualityMapping:
     dtype_value_pairs = []
     for name, value in mapping.items():

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -331,6 +331,59 @@ def test_eigvalsh(x):
 
     # TODO: Test that res actually corresponds to the eigenvalues of x
 
+
+@pytest.mark.unvectorized
+@pytest.mark.xp_extension('linalg')
+@pytest.mark.min_version("2025.12")
+@given(x=arrays(dtype=all_floating_dtypes(), shape=square_matrix_shapes))
+def test_eig(x):
+    res = linalg.eig(x)
+
+    _test_namedtuple(res, ['eigenvalues', 'eigenvectors'], 'eig')
+
+    eigenvalues = res.eigenvalues
+    eigenvectors = res.eigenvectors
+    expected_dtype = dh.complex_dtype_for(x.dtype)
+
+    ph.assert_dtype("eig", in_dtype=x.dtype, out_dtype=eigenvalues.dtype,
+                    expected=expected_dtype, repr_name="eigenvalues.dtype")
+    ph.assert_result_shape("eig", in_shapes=[x.shape],
+                           out_shape=eigenvalues.shape,
+                           expected=x.shape[:-1],
+                           repr_name="eigenvalues.shape")
+
+    ph.assert_dtype("eig", in_dtype=x.dtype, out_dtype=eigenvectors.dtype,
+                    expected=expected_dtype, repr_name="eigenvectors.dtype")
+    ph.assert_result_shape("eig", in_shapes=[x.shape],
+                           out_shape=eigenvectors.shape, expected=x.shape,
+                           repr_name="eigenvectors.shape")
+
+    # TODO: Test that eigenvectors are orthonormal.
+
+    _test_stacks(lambda x: linalg.eig(x).eigenvectors, x,
+                 res=eigenvectors, dims=2)
+
+    # TODO: Test that res actually corresponds to the eigenvalues and
+    # eigenvectors of x
+
+
+@pytest.mark.unvectorized
+@pytest.mark.xp_extension('linalg')
+@pytest.mark.min_version("2025.12")
+@given(x=arrays(dtype=all_floating_dtypes(), shape=square_matrix_shapes))
+def test_eigvals(x):
+    res = linalg.eigvals(x)
+    expected_dtype = dh.complex_dtype_for(x.dtype)
+
+    ph.assert_dtype("eigvals", in_dtype=x.dtype, out_dtype=res.dtype,
+                    expected=expected_dtype, repr_name="eigvals")
+    ph.assert_result_shape("eigvals", in_shapes=[x.shape],
+                           out_shape=res.shape, expected=x.shape[:-1])
+    # TODO: Test that res actually corresponds to the eigenvalues of x
+
+    _test_stacks(linalg.eigvals, x, res=res, dims=1)
+
+
 @pytest.mark.unvectorized
 @pytest.mark.xp_extension('linalg')
 @given(x=invertible_matrices())


### PR DESCRIPTION
Local testing:

- [x] `torch`
- [ ] `numpy`: need a workaround for dtypes : https://github.com/data-apis/array-api-compat/pull/379
- [ ] `cupy` : xfail for cupy < 14, need a workaround otherwise? : https://github.com/data-apis/array-api-compat/pull/379
- [ ]  `dask` : https://github.com/data-apis/array-api-compat/pull/379
- [x] `array-api-strict` : https://github.com/data-apis/array-api-strict/pull/178
