### PR TITLE
ENH: Test return values which changes from lists to tuples in 2025.12

### DIFF
--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -13,6 +13,7 @@ from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
 from .typing import DataType, Scalar
+from . import api_version
 
 
 class frange(NamedTuple):
@@ -569,6 +570,8 @@ def test_meshgrid(dtype, kw, data):
     repro_snippet = ph.format_snippet(f"xp.meshgrid(*arrays, **kw) with {arrays = } and {kw = }")
     try:
         out = xp.meshgrid(*arrays, **kw)
+
+        assert type(out) == (list if api_version < "2025.12" else tuple)
         for i, x in enumerate(out):
             ph.assert_dtype("meshgrid", in_dtype=dtype, out_dtype=x.dtype, repr_name=f"out[{i}].dtype")
             ph.assert_shape("meshgrid", out_shape=x.shape, expected=tgt_shape)

--- a/array_api_tests/test_data_type_functions.py
+++ b/array_api_tests/test_data_type_functions.py
@@ -12,7 +12,7 @@ from . import pytest_helpers as ph
 from . import shape_helpers as sh
 from . import xps
 from .typing import DataType
-
+from . import api_version
 
 # TODO: test with complex dtypes
 def non_complex_dtypes():
@@ -106,6 +106,8 @@ def test_broadcast_arrays(shapes, data):
     repro_snippet = ph.format_snippet(f"xp.broadcast_arrays(*arrays) with {arrays = }")
     try:
         out = xp.broadcast_arrays(*arrays)
+
+        assert type(out) == (list if api_version < "2025.12" else tuple)
 
         expected_shape = sh.broadcast_shapes(*shapes)
         for i, x in enumerate(arrays):

--- a/array_api_tests/test_inspection_functions.py
+++ b/array_api_tests/test_inspection_functions.py
@@ -3,6 +3,7 @@ from hypothesis import given, strategies as st
 from array_api_tests.dtype_helpers import available_kinds, dtype_names
 
 from . import xp
+from . import api_version
 
 pytestmark = pytest.mark.min_version("2023.12")
 
@@ -31,7 +32,7 @@ class TestInspection:
         assert hasattr(out, "devices")
         assert hasattr(out, "default_device")
 
-        assert isinstance(out.devices(), list)
+        assert isinstance(out.devices(), list if api_version < "2025.12" else tuple)
         if out.default_device() is not None:
             # Per https://github.com/data-apis/array-api/issues/923
             # default_device() can return None. Otherwise, it must be a valid device.


### PR DESCRIPTION
`broadcast_arrays`, `meshgrid` and `__array_namespace_info__().devices()`

Draft until 2025.12 is released.
Matching `-compat` PR: https://github.com/data-apis/array-api-compat/pull/380
Matching `-strict` PR: https://github.com/data-apis/array-api-strict/pull/179

