### PR TITLE
ENH: `expand_dims` tuple axes

### DIFF
--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -156,6 +156,7 @@ class TestExpandDims:
             ph.add_note(exc, repro_snippet)
             raise
 
+    @pytest.mark.min_version("2025.12")
     @given(
         x=hh.arrays(dtype=hh.all_dtypes, shape=shared_shapes(max_dims=4)),
         axes=shared_shapes().flatmap(


### PR DESCRIPTION
cross-ref https://github.com/data-apis/array-api/pull/988


needs https://github.com/data-apis/array-api-compat/pull/385 for the torch wrapper, 

