### PR TITLE
ENH: unskip test_{std,var}

### DIFF
--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -338,7 +338,6 @@ def test_prod(x, data):
         raise
 
 
-@pytest.mark.skip(reason="flaky")  # TODO: fix!
 @given(
     x=hh.arrays(
         dtype=hh.real_floating_dtypes,
@@ -456,7 +455,6 @@ def test_sum(x, data):
 
 
 @pytest.mark.unvectorized
-@pytest.mark.skip(reason="flaky")  # TODO: fix!
 @given(
     x=hh.arrays(
         dtype=hh.real_floating_dtypes,


### PR DESCRIPTION
Remove skips from `test_std` and `test_var`. They are skipped as flaky (cross-ref https://github.com/data-apis/array-api-tests/issues/300), but I cannot reproduce failures anymore:

```
(array-api) br@gonzales:~/repos/array-api-tests$ ARRAY_API_TESTS_MODULE=array_api_compat.numpy pytest --disable-warnings array_api_tests/test_statistical_functions.py -k std -v --hypothesis-seed=146745493194750825545715057348996307346 --max-examples=50_000 --hypothesis-verbosity=verbose --hypothesis-show-statistics
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.12.0, pytest-8.3.5, pluggy-1.5.0 -- /home/br/miniforge3/envs/array-api/bin/python3.12
cachedir: .pytest_cache
metadata: {'Python': '3.12.0', 'Platform': 'Linux-5.15.0-76-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '8.3.5', 'pluggy': '1.5.0'}, 'Plugins': {'json-report': '1.5.0', 'xdist': '3.6.1', 'metadata': '3.1.1', 'hypothesis': '6.150.0'}, 'array_api_tests_module': 'array_api_tests._array_module', 'array_api_tests_version': '2025.05.23+68.gc0e148c.dirty'}
hypothesis profile 'array-api-tests-with-verbose-verbosity' -> max_examples=50000, verbosity=Verbosity.verbose, deadline=timedelta(milliseconds=800)
Environment variables:
----------------------
ARRAY_API_TESTS_MODULE = array_api_compat.numpy

Array API Tests Module: array_api_compat.numpy (2.3.5). API Version: 2024.12. Enabled Extensions: fft, linalg
rootdir: /home/br/repos/array-api-tests
configfile: pytest.ini
plugins: json-report-1.5.0, xdist-3.6.1, metadata-3.1.1, hypothesis-6.150.0
collected 9 items / 8 deselected / 1 selected                                                                                                                            

array_api_tests/test_statistical_functions.py::test_std PASSED                                                                                                     [100%]
========================================================================= Hypothesis Statistics ==========================================================================

array_api_tests/test_statistical_functions.py::test_std:

  - during generate phase (476.65 seconds):
    - Typical runtimes: ~ 3-10 ms, of which ~ 1-4 ms in data generation
    - 50000 passing examples, 0 failing examples, 9145 invalid examples
    - Events:
      * 21.78%, Retried draw from builds(_f, sampled_from((float32, float64)).flatmap(lambda d: arrays(d, *args, elements=elements, **kwargs)), booleans()).filter(lambda x: math.prod(x.shape) >= 2) to satisfy filter
      * 7.44%, invalid because: Aborted test because unable to satisfy builds(_f, sampled_from((float32, float64)).flatmap(lambda d: arrays(d, *args, elements=elements, **kwargs)), booleans()).filter(lambda x: math.prod(x.shape) >= 2)
      * 2.56%, Retried draw from integers(0, 3).map(lambda x: x if x < ndim else x - 2 * ndim).filter(not_yet_in_unique_list) to satisfy filter

  - Stopped because settings.max_examples=50000

```