### PR TITLE
BUG: fix the regex to parse the dtype category from the docstring

### DIFF
--- a/array_api_tests/dtype_helpers.py
+++ b/array_api_tests/dtype_helpers.py
@@ -447,7 +447,14 @@ def result_type(*dtypes: DataType):
 
 
 r_alias = re.compile("[aA]lias")
-r_in_dtypes = re.compile("x1?: array\n.+have an? (.+) data type.")
+
+r_in_dtypes = re.compile(
+    r'(?:x(?:1)?: (?:Union\[)?array(?:, (?:int|float|complex|bool))*(?:\])?\s*\n.+?'
+    r'(?:x2: (?:Union\[)?array(?:, (?:int|float|complex|bool))*(?:\])?\s*\n.+?)?)?'
+    r'Should have an? (boolean|integer or boolean|real-valued floating-point|complex floating-point|real-valued|floating-point|integer|numeric) data type\.',
+    re.DOTALL
+)
+
 r_int_note = re.compile(
     "If one or both of the input arrays have integer data types, "
     "the result is implementation-dependent"


### PR DESCRIPTION
This was making a bunch of test_signature tests fail / be xfailed. The core of the change is that the regex was looking for `x1: array` while from 2024.12 the text was `x1: Union[array | int]` etc.

This was mostly harmless, modulo bitwise functions (`bitwise_left_shift` etc) which we incorrectly classed as being able to receive `"numeric"` inputs.

The regex fix is by copilot.