### PR TITLE
MAINT: only draw signed ints for `repeats` in test_repeat

### DIFF
--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -328,8 +328,10 @@ def test_repeat(x, kw, data):
     axis = kw.get("axis", None)
     size = math.prod(shape) if axis is None else shape[axis]
     repeat_strat = st.integers(1, 10)
+    # TODO: draw `repeats` from hh.all_int_types to include unsigned ints
+    # That however breaks down on torch (unit8) and numpy (uint64)
     repeats = data.draw(repeat_strat
-                        | hh.arrays(dtype=hh.all_int_dtypes, elements=repeat_strat,
+                        | hh.arrays(dtype=hh.int_dtypes, elements=repeat_strat,
                                     shape=st.sampled_from([(1,), (size,)])),
         label="repeats")
     if isinstance(repeats, int):


### PR DESCRIPTION
Strictly speaking, the spec requires all integers. However uints make us skip the test on _all_ -compat-wrapped libraries.

closes https://github.com/data-apis/array-api-tests/issues/413