### PR TITLE
ENH: reshape: test copy= kwarg

### DIFF
--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -428,13 +428,15 @@ reshape_shape = st.shared(hh.shapes(), key="reshape_shape")
 @given(
     x=hh.arrays(dtype=hh.all_dtypes, shape=reshape_shape),
     shape=hh.reshape_shapes(reshape_shape),
+    kw=hh.kwargs(copy=st.booleans())
 )
-def test_reshape(x, shape):
-    repro_snippet = ph.format_snippet(f"xp.reshape({x!r},{shape!r})")
+def test_reshape(x, shape, kw):
+    repro_snippet = ph.format_snippet(f"xp.reshape({x!r},{shape!r}, **kw) with {kw =}")
     try: 
-        out = xp.reshape(x, shape)
+        out = xp.reshape(x, shape, **kw)
 
         ph.assert_dtype("reshape", in_dtype=x.dtype, out_dtype=out.dtype)
+        # TODO: test copy
 
         _shape = list(shape)
         if any(side == -1 for side in shape):

--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -428,11 +428,12 @@ reshape_shape = st.shared(hh.shapes(), key="reshape_shape")
 @given(
     x=hh.arrays(dtype=hh.all_dtypes, shape=reshape_shape),
     shape=hh.reshape_shapes(reshape_shape),
+    kw=hh.kwargs(copy=st.booleans() | st.none())
 )
-def test_reshape(x, shape):
-    repro_snippet = ph.format_snippet(f"xp.reshape({x!r},{shape!r})")
-    try: 
-        out = xp.reshape(x, shape)
+def test_reshape(x, shape, kw):
+    repro_snippet = ph.format_snippet(f"xp.reshape({x!r},{shape!r}, **kw) with {kw =}")
+    try:
+        out = xp.reshape(x, shape, **kw)
 
         ph.assert_dtype("reshape", in_dtype=x.dtype, out_dtype=out.dtype)
 


### PR DESCRIPTION
Apparently, `copy=` kwarg of `reshape` is <s>not very well</s> reasonably well supported:

- [x] torch does not have it (https://docs.pytorch.org/docs/stable/generated/torch.reshape.html), and array-api-compat simply raises -- fixed by https://github.com/data-apis/array-api-compat/pull/457
- [x] cupy will have it soon-ish (in cupy==14.0 via https://github.com/cupy/cupy/pull/10147); for now, there's a workaround in `array_api_compat`
- [x] jax.numpy has it but always copies anyway (unless jit elides the copy)

Where the argument is supported, the test itself needs work:
- [x] on `-strict`, zero-sized arrays fail some internal check with `copy=True` -- fixed by https://github.com/data-apis/array-api-strict/pull/232
- [x] on `numpy`, the test generates arrays or numpy scalars, and scalars choke something in the test itself. -- fixed by https://github.com/data-apis/array-api-compat/pull/454
