### PR TITLE
ENH: allow running on torch.mps device, which does not have float64/complex128

### DIFF
--- a/array_api_tests/hypothesis_helpers.py
+++ b/array_api_tests/hypothesis_helpers.py
@@ -341,8 +341,8 @@ def finite_matrices(draw, shape=matrix_shapes(), dtype=floating_dtypes, bound=No
 
 
 rtol_shared_matrix_shapes = shared(matrix_shapes())
-# Should we set a max_value here?
-_rtol_float_kw = dict(allow_nan=False, allow_infinity=False, min_value=0)
+# Arbitrary max_value for rtols, to avoid overflows when float64 is not available
+_rtol_float_kw = dict(allow_nan=False, allow_infinity=False, min_value=0, max_value=42)
 rtols = one_of(floats(**_rtol_float_kw),
                arrays(dtype=real_floating_dtypes,
                           shape=rtol_shared_matrix_shapes.map(lambda shape:  shape[:-2]),

--- a/array_api_tests/test_signatures.py
+++ b/array_api_tests/test_signatures.py
@@ -156,7 +156,10 @@ for func_name, func in name_to_func.items():
     array_argnames -= set(func_to_specified_arg_exprs[func_name].keys())
     if len(array_argnames) > 0:
         in_dtypes = dh.func_in_dtypes[func_name]
-        for dtype_name in ["float64", "bool", "int64", "complex128"]:
+        # use "float64" if available, "float32" otherwise; ditto for complex128/complex64
+        float_name = dh.dtype_to_name[dh.widest_real_dtype]
+        cmplx_name = dh.dtype_to_name[dh.widest_complex_dtype]
+        for dtype_name in [float_name, "bool", "int64", cmplx_name]:
             # We try float64 first because uninspectable numerical functions
             # tend to support float inputs first-and-foremost (i.e. PyTorch)
             try:


### PR DESCRIPTION
towards https://github.com/data-apis/array-api-tests/issues/431

Adding the following to `__init__.py`

```
import array_api_compat.torch as xp
xp_name = xp.__name__
xp.set_default_device("mps")
```

and running

```
$ ARRAY_API_TESTS_SKIP_DTYPES=uint32,uint64,uint16,float64,complex128  pytest array_api_tests/ -vs --skips-file=../array-api-compat/torch-xfails.txt --max-examples=10
```

generates *a lot* of failures, which, however, fall into three categories:

1. `test_special_cases` : a lot of edge cases are not implemented on an MPS device;
2. linear algebra: `aten::linalg_eig' is not currently implemented`, also `aten::_linalg_svd.U`, `aten::linalg_qr.out`
3. assorted edge cases on MPS with numerically large values: for instance, `test_linspace` fails on MPS and passes on CPU:


```
(Pdb) xp.linspace(start, stop, 100, dtype=xp.float32)[-1] - stop
tensor(-67108864., device='mps:0')
(Pdb) p np.linspace(start, stop, 100, dtype=np.float32)[-1] - stop
np.float32(0.0)
(Pdb) p np.linspace(start, stop, 100, dtype=np.float32, device="cpu")[-1] - stop
np.float32(0.0)
(Pdb) start, stop, num
(0.0, 1072614462193664.0, 100)
```
