### PR TITLE
ENH: use int32 not int64 in test_elementwise

### DIFF
--- a/array_api_tests/test_operators_and_elementwise_functions.py
+++ b/array_api_tests/test_operators_and_elementwise_functions.py
@@ -2218,7 +2218,7 @@ def test_binary_with_scalars_bool(func_data, x1x2):
     ],
     ids=lambda func_data: func_data[0]  # use names for test IDs
 )
-@given(x1x2=hh.array_and_py_scalar([xp.int64]))
+@given(x1x2=hh.array_and_py_scalar([xp.int32]))
 def test_binary_with_scalars_int(func_data, x1x2):
     assume(_filter_zero(x1x2[1]))
     assume(_filter_zero(x1x2[0]) and _filter_zero(x1x2[1]))


### PR DESCRIPTION
Allows to avoid a failure under JAX w/out JAX_ENABLE_X64 variable (so that there int64 dtype is not available).

towards gh-431