### PR TITLE
TST: test var(complex_array) and std(complex_array)

### DIFF
--- a/array_api_tests/test_statistical_functions.py
+++ b/array_api_tests/test_statistical_functions.py
@@ -340,7 +340,7 @@ def test_prod(x, data):
 
 @given(
     x=hh.arrays(
-        dtype=hh.real_floating_dtypes,
+        dtype=hh.floating_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ).filter(lambda x: math.prod(x.shape) >= 2),
@@ -369,7 +369,7 @@ def test_std(x, data):
     try:
         out = xp.std(x, **kw)
 
-        ph.assert_dtype("std", in_dtype=x.dtype, out_dtype=out.dtype)
+        ph.assert_dtype("std", in_dtype=x.dtype, out_dtype=out.dtype, expected=dh.real_dtype_for(x.dtype))
         ph.assert_keepdimable_shape(
             "std", in_shape=x.shape, out_shape=out.shape, axes=_axes, keepdims=keepdims, kw=kw
         )
@@ -457,7 +457,7 @@ def test_sum(x, data):
 @pytest.mark.unvectorized
 @given(
     x=hh.arrays(
-        dtype=hh.real_floating_dtypes,
+        dtype=hh.floating_dtypes,
         shape=hh.shapes(min_side=1),
         elements={"allow_nan": False},
     ).filter(lambda x: math.prod(x.shape) >= 2),
@@ -486,7 +486,7 @@ def test_var(x, data):
     try:
         out = xp.var(x, **kw)
 
-        ph.assert_dtype("var", in_dtype=x.dtype, out_dtype=out.dtype)
+        ph.assert_dtype("var", in_dtype=x.dtype, out_dtype=out.dtype, expected=dh.real_dtype_for(x.dtype))
         ph.assert_keepdimable_shape(
             "var", in_shape=x.shape, out_shape=out.shape, axes=_axes, keepdims=keepdims, kw=kw
         )


### PR DESCRIPTION
Cross-ref https://github.com/data-apis/array-api/issues/1007, tentatively okay'd in the community meeting, https://hackmd.io/zn5bvdZTQIeJmb3RW1B-8g#Meeting-minutes-25-June-2026

Local tests:

- [x]  numpy: `$ ARRAY_API_TESTS_MODULE=array_api_compat.numpy pytest array_api_tests/test_statistical_functions.py::test_var   --max-examples=10_000`  and `$ ARRAY_API_TESTS_MODULE=array_api_compat.numpy pytest array_api_tests/test_statistical_functions.py::test_std   --max-examples=10_000` both pass. 

- [ ] torch:  needs https://github.com/data-apis/array-api-compat/pull/445, then   `$ ARRAY_API_TESTS_SKIP_DTYPES=uint16,uint32,uint64 ARRAY_API_TESTS_MODULE=array_api_compat.torch pytest array_api_tests/test_statistical_functions.py::test_std   --max-examples=10_000`  passes

- [x] cupy : `$ ARRAY_API_TESTS_MODULE=array_api_compat.cupy pytest array_api_tests/test_statistical_functions.py::test_std   --max-examples=10_000 --disable-deadline` passes

- [x] jax.numpy : `$ JAX_ENABLE_X64=true ARRAY_API_TESTS_MODULE=jax.numpy pytest array_api_tests/test_statistical_functions.py::test_std   --max-examples=10_000 --disable-deadline` passes  

- [ ] -strict: needs https://github.com/data-apis/array-api-strict/pull/214, then `$ ARRAY_API_TESTS_MODULE=array_api_strict pytest array_api_tests/test_statistical_functions.py::test_var   --max-examples=10_000` passes