### PR TITLE
WIP: test `top k`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "array_api_tests/array-api"]
 	path = array-api
-	url = https://github.com/data-apis/array-api/
+#	url = https://github.com/data-apis/array-api/
+    url = https://github.com/kgryte/array-api/tree/feat/top_k

--- a/array_api_tests/_array_module.py
+++ b/array_api_tests/_array_module.py
@@ -35,6 +35,9 @@ _funcs = [f.__name__ for funcs in stubs.category_to_funcs.values() for f in func
 _funcs += ["take", "isdtype", "conj", "imag", "real"]  # TODO: bump spec and update array-api-tests to new spec layout
 _top_level_attrs = _dtypes + _constants + _funcs + stubs.EXTENSIONS + ["fft"]
 
+# FIXME
+_funcs += ["top_k"]
+
 for attr in _top_level_attrs:
     try:
         globals()[attr] = getattr(xp, attr)

--- a/array_api_tests/test_searching_functions.py
+++ b/array_api_tests/test_searching_functions.py
@@ -3,7 +3,6 @@ import math
 import pytest
 from hypothesis import given, note, assume
 from hypothesis import strategies as st
-from hypothesis.control import assume
 
 from . import _array_module as xp
 from . import dtype_helpers as dh
@@ -351,20 +350,33 @@ def test_searchsorted_with_scalars(data):
         shape=hh.shapes(min_dims=1, min_side=1),
         elements={"allow_nan": False},
     ),
+    mode_kw=hh.kwargs(mode=st.sampled_from(['largest', 'smallest'])),
     data=st.data()
 )
-def test_top_k(x, data):
+def test_top_k(x, mode_kw, data,):
 
-    if dh.is_float_dtype(x.dtype):
-        assume(not xp.any(x == -0.0) and not xp.any(x == +0.0))
+#    if dh.is_float_dtype(x.dtype):
+#        assume(not xp.any(x == -0.0) and not xp.any(x == +0.0))
 
-    axis = data.draw(
-        st.integers(-x.ndim, x.ndim - 1), label='axis')
+    # XXX: default -1
+    axis = data.draw(st.integers(-x.ndim, x.ndim - 1), label='axis')
+    k = data.draw(st.integers(1, x.shape[axis]))
+
+    repro_snippet = ph.format_snippet(
+        f"xp.top_k(x, k, axis=axis, **mode_kw) with {mode_kw = }"
+    )
+    try:
+        out_values, out_indices = xp.top_k(x, k, axis=axis, **mode_kw)
+
+
+    except Exception as exc:
+        ph.add_note(exc, repro_snippet)
+        raise
+
+
+"""
     largest = data.draw(st.booleans(), label='largest')
-    if axis is None:
-        k = data.draw(st.integers(1, math.prod(x.shape)))
-    else:
-        k = data.draw(st.integers(1, x.shape[axis]))
+
 
     kw = dict(
         x=x,
@@ -373,7 +385,15 @@ def test_top_k(x, data):
         largest=largest,
     )
 
-    (out_values, out_indices) = xp.top_k(x, k, axis, largest=largest)
+
+
+
+
+    out_values, out_indices = xp.top_k(x, k, axis, largest=largest)
+
+
+
+
     if axis is None:
         x = xp.reshape(x, (-1,))
         axis = 0
@@ -440,4 +460,4 @@ def test_top_k(x, data):
                 out_val=x[y_idx],
                 kw=kw
             )
->>>>>>> WIP: top_k tests
+"""

--- a/array_api_tests/test_searching_functions.py
+++ b/array_api_tests/test_searching_functions.py
@@ -369,7 +369,7 @@ def test_top_k(x, mode_kw, data,):
     )
     try:
 
-        print(x.dtype, k, axis, axis_kw)
+        print(x.dtype, k, axis, axis_kw, mode_kw)
 
         out_values, out_indices = xp.top_k(x, k, **axis_kw, **mode_kw)
 

--- a/array_api_tests/test_searching_functions.py
+++ b/array_api_tests/test_searching_functions.py
@@ -358,15 +358,38 @@ def test_top_k(x, mode_kw, data,):
 #    if dh.is_float_dtype(x.dtype):
 #        assume(not xp.any(x == -0.0) and not xp.any(x == +0.0))
 
-    # XXX: default -1
-    axis = data.draw(st.integers(-x.ndim, x.ndim - 1), label='axis')
+    # default axis=-1
+    axis_kw = data.draw(hh.kwargs(axis=st.integers(-x.ndim, x.ndim - 1)))
+    axis = axis_kw.get('axis', -1)
+
     k = data.draw(st.integers(1, x.shape[axis]))
 
     repro_snippet = ph.format_snippet(
-        f"xp.top_k(x, k, axis=axis, **mode_kw) with {mode_kw = }"
+        f"xp.top_k(x, k, **axis_kw, **mode_kw) with {axis_kw = } and {mode_kw = }"
     )
     try:
-        out_values, out_indices = xp.top_k(x, k, axis=axis, **mode_kw)
+
+        print(x.dtype, k, axis, axis_kw)
+
+        out_values, out_indices = xp.top_k(x, k, **axis_kw, **mode_kw)
+
+        ph.assert_dtype("top_k", in_dtype=x.dtype, out_dtype=out_values.dtype)
+        ph.assert_dtype(
+            "top_k",
+            in_dtype=x.dtype,
+            out_dtype=out_indices.dtype,
+            expected=dh.default_int
+        )
+
+        axes, = sh.normalize_axis(axis, x.ndim)
+        for arr in [out_values, out_indices]:
+            ph.assert_shape(
+                "top_k",
+                out_shape=arr.shape,
+                expected=x.shape[:axes] + (k,) + x.shape[axes + 1:],
+            )
+
+        # TODO: test values
 
 
     except Exception as exc:
@@ -375,45 +398,6 @@ def test_top_k(x, mode_kw, data,):
 
 
 """
-    largest = data.draw(st.booleans(), label='largest')
-
-
-    kw = dict(
-        x=x,
-        k=k,
-        axis=axis,
-        largest=largest,
-    )
-
-
-
-
-
-    out_values, out_indices = xp.top_k(x, k, axis, largest=largest)
-
-
-
-
-    if axis is None:
-        x = xp.reshape(x, (-1,))
-        axis = 0
-
-    ph.assert_dtype("top_k", in_dtype=x.dtype, out_dtype=out_values.dtype)
-    ph.assert_dtype(
-        "top_k",
-        in_dtype=x.dtype,
-        out_dtype=out_indices.dtype,
-        expected=dh.default_int
-    )
-    axes, = sh.normalise_axis(axis, x.ndim)
-    for arr in [out_values, out_indices]:
-        ph.assert_shape(
-            "top_k",
-            out_shape=arr.shape,
-            expected=x.shape[:axes] + (k,) + x.shape[axes + 1:],
-            kw=kw
-        )
-
     scalar_type = dh.get_scalar_type(x.dtype)
 
     for indices in sh.axes_ndindex(x.shape, (axes,)):

--- a/array_api_tests/test_searching_functions.py
+++ b/array_api_tests/test_searching_functions.py
@@ -3,6 +3,7 @@ import math
 import pytest
 from hypothesis import given, note, assume
 from hypothesis import strategies as st
+from hypothesis.control import assume
 
 from . import _array_module as xp
 from . import dtype_helpers as dh
@@ -340,3 +341,103 @@ def test_searchsorted_with_scalars(data):
     except Exception as exc:
         ph.add_note(exc, repro_snippet)
         raise
+
+
+@pytest.mark.unvectorized
+# TODO: Test with signed zeros and NaNs (and ignore them somehow)
+@given(
+    x=hh.arrays(
+        dtype=hh.real_dtypes,
+        shape=hh.shapes(min_dims=1, min_side=1),
+        elements={"allow_nan": False},
+    ),
+    data=st.data()
+)
+def test_top_k(x, data):
+
+    if dh.is_float_dtype(x.dtype):
+        assume(not xp.any(x == -0.0) and not xp.any(x == +0.0))
+
+    axis = data.draw(
+        st.integers(-x.ndim, x.ndim - 1), label='axis')
+    largest = data.draw(st.booleans(), label='largest')
+    if axis is None:
+        k = data.draw(st.integers(1, math.prod(x.shape)))
+    else:
+        k = data.draw(st.integers(1, x.shape[axis]))
+
+    kw = dict(
+        x=x,
+        k=k,
+        axis=axis,
+        largest=largest,
+    )
+
+    (out_values, out_indices) = xp.top_k(x, k, axis, largest=largest)
+    if axis is None:
+        x = xp.reshape(x, (-1,))
+        axis = 0
+
+    ph.assert_dtype("top_k", in_dtype=x.dtype, out_dtype=out_values.dtype)
+    ph.assert_dtype(
+        "top_k",
+        in_dtype=x.dtype,
+        out_dtype=out_indices.dtype,
+        expected=dh.default_int
+    )
+    axes, = sh.normalise_axis(axis, x.ndim)
+    for arr in [out_values, out_indices]:
+        ph.assert_shape(
+            "top_k",
+            out_shape=arr.shape,
+            expected=x.shape[:axes] + (k,) + x.shape[axes + 1:],
+            kw=kw
+        )
+
+    scalar_type = dh.get_scalar_type(x.dtype)
+
+    for indices in sh.axes_ndindex(x.shape, (axes,)):
+
+        # Test if the values indexed by out_indices corresponds to
+        # the correct top_k values.
+        elements = [scalar_type(x[idx]) for idx in indices]
+        size = len(elements)
+        correct_order = sorted(
+            range(size),
+            key=elements.__getitem__,
+            reverse=largest
+        )
+        correct_order = correct_order[:k]
+        test_order = [out_indices[idx] for idx in indices[:k]]
+        # Sort because top_k does not necessarily return the values in
+        # sorted order.
+        test_sorted_order = sorted(
+            test_order,
+            key=elements.__getitem__,
+            reverse=largest
+        )
+
+        for y_o, x_o in zip(correct_order, test_sorted_order):
+            y_idx = indices[y_o]
+            x_idx = indices[x_o]
+            ph.assert_0d_equals(
+                "top_k",
+                x_repr=f"x[{x_idx}]",
+                x_val=x[x_idx],
+                out_repr=f"x[{y_idx}]",
+                out_val=x[y_idx],
+                kw=kw,
+            )
+
+        # Test if the values indexed by out_indices corresponds to out_values.
+        for y_o, x_idx in zip(test_order, indices[:k]):
+            y_idx = indices[y_o]
+            ph.assert_0d_equals(
+                "top_k",
+                x_repr=f"out_values[{x_idx}]",
+                x_val=scalar_type(out_values[x_idx]),
+                out_repr=f"x[{y_idx}]",
+                out_val=x[y_idx],
+                kw=kw
+            )
+>>>>>>> WIP: top_k tests

--- a/array_api_tests/test_searching_functions.py
+++ b/array_api_tests/test_searching_functions.py
@@ -342,8 +342,7 @@ def test_searchsorted_with_scalars(data):
         raise
 
 
-@pytest.mark.unvectorized
-# TODO: Test with signed zeros and NaNs (and ignore them somehow)
+# TODO: min_version
 @given(
     x=hh.arrays(
         dtype=hh.real_dtypes,
@@ -354,10 +353,6 @@ def test_searchsorted_with_scalars(data):
     data=st.data()
 )
 def test_top_k(x, mode_kw, data,):
-
-#    if dh.is_float_dtype(x.dtype):
-#        assume(not xp.any(x == -0.0) and not xp.any(x == +0.0))
-
     # default axis=-1
     axis_kw = data.draw(hh.kwargs(axis=st.integers(-x.ndim, x.ndim - 1)))
     axis = axis_kw.get('axis', -1)
@@ -365,12 +360,9 @@ def test_top_k(x, mode_kw, data,):
     k = data.draw(st.integers(1, x.shape[axis]))
 
     repro_snippet = ph.format_snippet(
-        f"xp.top_k(x, k, **axis_kw, **mode_kw) with {axis_kw = } and {mode_kw = }"
+        f"xp.top_k({x!r}, {k}, **axis_kw, **mode_kw) with {axis_kw = } and {mode_kw = }"
     )
     try:
-
-        print(x.dtype, k, axis, axis_kw, mode_kw)
-
         out_values, out_indices = xp.top_k(x, k, **axis_kw, **mode_kw)
 
         ph.assert_dtype("top_k", in_dtype=x.dtype, out_dtype=out_values.dtype)
@@ -388,60 +380,7 @@ def test_top_k(x, mode_kw, data,):
                 out_shape=arr.shape,
                 expected=x.shape[:axes] + (k,) + x.shape[axes + 1:],
             )
-
-        # TODO: test values
-
-
+        # TODO: values testing, test with signed zeros and NaNs
     except Exception as exc:
         ph.add_note(exc, repro_snippet)
         raise
-
-
-"""
-    scalar_type = dh.get_scalar_type(x.dtype)
-
-    for indices in sh.axes_ndindex(x.shape, (axes,)):
-
-        # Test if the values indexed by out_indices corresponds to
-        # the correct top_k values.
-        elements = [scalar_type(x[idx]) for idx in indices]
-        size = len(elements)
-        correct_order = sorted(
-            range(size),
-            key=elements.__getitem__,
-            reverse=largest
-        )
-        correct_order = correct_order[:k]
-        test_order = [out_indices[idx] for idx in indices[:k]]
-        # Sort because top_k does not necessarily return the values in
-        # sorted order.
-        test_sorted_order = sorted(
-            test_order,
-            key=elements.__getitem__,
-            reverse=largest
-        )
-
-        for y_o, x_o in zip(correct_order, test_sorted_order):
-            y_idx = indices[y_o]
-            x_idx = indices[x_o]
-            ph.assert_0d_equals(
-                "top_k",
-                x_repr=f"x[{x_idx}]",
-                x_val=x[x_idx],
-                out_repr=f"x[{y_idx}]",
-                out_val=x[y_idx],
-                kw=kw,
-            )
-
-        # Test if the values indexed by out_indices corresponds to out_values.
-        for y_o, x_idx in zip(test_order, indices[:k]):
-            y_idx = indices[y_o]
-            ph.assert_0d_equals(
-                "top_k",
-                x_repr=f"out_values[{x_idx}]",
-                x_val=scalar_type(out_values[x_idx]),
-                out_repr=f"x[{y_idx}]",
-                out_val=x[y_idx],
-                kw=kw
-            )
-"""


### PR DESCRIPTION
Includes, supersedes and closes gh-274.

Add testing of `top_k`, per https://github.com/data-apis/array-api/pull/722/

Matching implementations and testing:

- [ ] `-strict`: https://github.com/data-apis/array-api-strict/pull/215
- [ ] `-compat.numpy` : works with https://github.com/numpy/numpy/pull/31659
- [ ] `-compat.torch` : https://github.com/data-apis/array-api-compat/pull/446
- [ ] `jax.numpy`
- [ ] `cupy`

