### PR TITLE
ENH: Adding tests for `tril` and `triu`

### DIFF
--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -392,29 +392,27 @@ def test_eye(n_rows, n_cols, kw):
         raise
 
 
-def _triangular_expected(x, *, k, upper):
-    expected = xp.zeros_like(x)
-    n, m = x.shape[-2:]
-    for idx in sh.ndindex(x.shape[:-2]):
-        for i in range(n):
-            for j in range(m):
-                keep = j <= i + k if not upper else j >= i + k
-                if keep:
-                    expected[idx + (i, j)] = x[idx + (i, j)]
-    return expected
-
 
 @given(x=hh.arrays(dtype=hh.numeric_dtypes, shape=hh.matrix_shapes()), data=st.data())
 def test_tril(x, data):
     n, m = x.shape[-2:]
-    k = data.draw(st.integers(min_value=-max(n, m, 1), max_value=max(n, m, 1)), label="k")
+    k = data.draw(
+        st.integers(min_value=-max(n, m, 1), max_value=max(n, m, 1)),
+        label="k",
+    )
     repro_snippet = ph.format_snippet(f"xp.tril({x!r}, k={k!r})")
     try:
         out = xp.tril(x, k=k)
         ph.assert_dtype("tril", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("tril", out_shape=out.shape, expected=x.shape)
-        expected = _triangular_expected(x, k=k, upper=False)
-        ph.assert_array_elements("tril", out=out, expected=expected, kw={"k": k})
+        for idx in sh.ndindex(out.shape):
+            *_, i, j = idx
+            expected = x[idx] if j <= i + k else xp.asarray(0, dtype=out.dtype)
+            ph.assert_array_elements(
+                "tril",
+                out=out[idx],
+                expected=expected,
+            )
     except Exception as exc:
         ph.add_note(exc, repro_snippet)
         raise
@@ -423,14 +421,23 @@ def test_tril(x, data):
 @given(x=hh.arrays(dtype=hh.numeric_dtypes, shape=hh.matrix_shapes()), data=st.data())
 def test_triu(x, data):
     n, m = x.shape[-2:]
-    k = data.draw(st.integers(min_value=-max(n, m, 1), max_value=max(n, m, 1)), label="k")
+    k = data.draw(
+        st.integers(min_value=-max(n, m, 1), max_value=max(n, m, 1)),
+        label="k",
+    )
     repro_snippet = ph.format_snippet(f"xp.triu({x!r}, k={k!r})")
     try:
         out = xp.triu(x, k=k)
         ph.assert_dtype("triu", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("triu", out_shape=out.shape, expected=x.shape)
-        expected = _triangular_expected(x, k=k, upper=True)
-        ph.assert_array_elements("triu", out=out, expected=expected, kw={"k": k})
+        for idx in sh.ndindex(out.shape):
+            *_, i, j = idx
+            expected = x[idx] if j >= i + k else xp.asarray(0, dtype=out.dtype)
+            ph.assert_array_elements(
+                "triu",
+                out=out[idx],
+                expected=expected,
+            )
     except Exception as exc:
         ph.add_note(exc, repro_snippet)
         raise

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -255,7 +255,6 @@ def test_asarray_scalars(shape, data):
             ph.assert_kw_dtype("asarray", kw_dtype=_dtype, out_dtype=out.dtype)
         ph.assert_shape("asarray", out_shape=out.shape, expected=shape)
         for idx, v_expect in zip(sh.ndindex(out.shape), _obj):
-            print(f"out.shape is : {out.shape} idx is:  {idx}")
             v = scalar_type(out[idx])
             ph.assert_scalar_equals("asarray", type_=scalar_type, idx=idx, out=v, expected=v_expect, kw=kw)
     except Exception as exc:
@@ -406,14 +405,17 @@ def test_tril(x, data):
         out = xp.tril(x, k=k)
         ph.assert_dtype("tril", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("tril", out_shape=out.shape, expected=x.shape)
+        zero = xp.asarray(0, dtype=out.dtype)
         expected_elements = [
                 x[idx] if idx[-1] <= idx[-2] + k 
-                else xp.asarray(0, dtype=out.dtype)
+                else zero
                 for idx in sh.ndindex(x.shape)
         ]
         if expected_elements:
             expected = xp.stack(expected_elements)
         else:
+            # xp.stack does not accept an empty sequence, and the dtype cannot
+            # be inferred when there are no elements, so use out.dtype explicitly.
             expected = xp.asarray([], dtype=out.dtype)
         expected = xp.reshape(expected, x.shape)
         ph.assert_array_elements(
@@ -438,9 +440,10 @@ def test_triu(x, data):
         out = xp.triu(x, k=k)
         ph.assert_dtype("triu", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("triu", out_shape=out.shape, expected=x.shape)
+        zero = xp.asarray(0, dtype=out.dtype)
         expected_elements = [
                 x[idx] if idx[-1] >= idx[-2] + k 
-                else xp.asarray(0, dtype=out.dtype)
+                else zero
                 for idx in sh.ndindex(x.shape)
         ]
         if expected_elements:

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -255,6 +255,7 @@ def test_asarray_scalars(shape, data):
             ph.assert_kw_dtype("asarray", kw_dtype=_dtype, out_dtype=out.dtype)
         ph.assert_shape("asarray", out_shape=out.shape, expected=shape)
         for idx, v_expect in zip(sh.ndindex(out.shape), _obj):
+            print(f"out.shape is : {out.shape} idx is:  {idx}")
             v = scalar_type(out[idx])
             ph.assert_scalar_equals("asarray", type_=scalar_type, idx=idx, out=v, expected=v_expect, kw=kw)
     except Exception as exc:
@@ -405,14 +406,19 @@ def test_tril(x, data):
         out = xp.tril(x, k=k)
         ph.assert_dtype("tril", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("tril", out_shape=out.shape, expected=x.shape)
-        for idx in sh.ndindex(out.shape):
-            *_, i, j = idx
-            expected = x[idx] if j <= i + k else xp.asarray(0, dtype=out.dtype)
-            ph.assert_array_elements(
-                "tril",
-                out=out[idx],
-                expected=expected,
-            )
+        expected = xp.asarray(
+            [
+                x[idx] if idx[-1] <= idx[-2] + k else 0
+                for idx in sh.ndindex(x.shape)
+            ],
+            dtype=out.dtype,
+        )
+        expected = xp.reshape(expected, x.shape)
+        ph.assert_array_elements(
+            "tril",
+            out=out,
+            expected=expected,
+        )
     except Exception as exc:
         ph.add_note(exc, repro_snippet)
         raise
@@ -430,18 +436,22 @@ def test_triu(x, data):
         out = xp.triu(x, k=k)
         ph.assert_dtype("triu", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("triu", out_shape=out.shape, expected=x.shape)
-        for idx in sh.ndindex(out.shape):
-            *_, i, j = idx
-            expected = x[idx] if j >= i + k else xp.asarray(0, dtype=out.dtype)
-            ph.assert_array_elements(
-                "triu",
-                out=out[idx],
-                expected=expected,
-            )
+        expected = xp.asarray(
+            [
+                x[idx] if idx[-1] >= idx[-2] + k else 0
+                for idx in sh.ndindex(x.shape)
+            ],
+            dtype=out.dtype,
+        )
+        expected = xp.reshape(expected, x.shape)
+        ph.assert_array_elements(
+            "triu",
+            out=out,
+            expected=expected,
+        )
     except Exception as exc:
         ph.add_note(exc, repro_snippet)
         raise
-
 
 default_unsafe_dtypes = [xp.uint64]
 if dh.default_int == xp.int32:

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -406,13 +406,15 @@ def test_tril(x, data):
         out = xp.tril(x, k=k)
         ph.assert_dtype("tril", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("tril", out_shape=out.shape, expected=x.shape)
-        expected = xp.asarray(
-            [
-                x[idx] if idx[-1] <= idx[-2] + k else 0
+        expected_elements = [
+                x[idx] if idx[-1] <= idx[-2] + k 
+                else xp.asarray(0, dtype=out.dtype)
                 for idx in sh.ndindex(x.shape)
-            ],
-            dtype=out.dtype,
-        )
+        ]
+        if expected_elements:
+            expected = xp.stack(expected_elements)
+        else:
+            expected = xp.asarray([], dtype=out.dtype)
         expected = xp.reshape(expected, x.shape)
         ph.assert_array_elements(
             "tril",
@@ -436,13 +438,15 @@ def test_triu(x, data):
         out = xp.triu(x, k=k)
         ph.assert_dtype("triu", in_dtype=x.dtype, out_dtype=out.dtype)
         ph.assert_shape("triu", out_shape=out.shape, expected=x.shape)
-        expected = xp.asarray(
-            [
-                x[idx] if idx[-1] >= idx[-2] + k else 0
+        expected_elements = [
+                x[idx] if idx[-1] >= idx[-2] + k 
+                else xp.asarray(0, dtype=out.dtype)
                 for idx in sh.ndindex(x.shape)
-            ],
-            dtype=out.dtype,
-        )
+        ]
+        if expected_elements:
+            expected = xp.stack(expected_elements)
+        else:
+            expected = xp.asarray([], dtype=out.dtype)
         expected = xp.reshape(expected, x.shape)
         ph.assert_array_elements(
             "triu",

--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -392,6 +392,50 @@ def test_eye(n_rows, n_cols, kw):
         raise
 
 
+def _triangular_expected(x, *, k, upper):
+    expected = xp.zeros_like(x)
+    n, m = x.shape[-2:]
+    for idx in sh.ndindex(x.shape[:-2]):
+        for i in range(n):
+            for j in range(m):
+                keep = j <= i + k if not upper else j >= i + k
+                if keep:
+                    expected[idx + (i, j)] = x[idx + (i, j)]
+    return expected
+
+
+@given(x=hh.arrays(dtype=hh.numeric_dtypes, shape=hh.matrix_shapes()), data=st.data())
+def test_tril(x, data):
+    n, m = x.shape[-2:]
+    k = data.draw(st.integers(min_value=-max(n, m, 1), max_value=max(n, m, 1)), label="k")
+    repro_snippet = ph.format_snippet(f"xp.tril({x!r}, k={k!r})")
+    try:
+        out = xp.tril(x, k=k)
+        ph.assert_dtype("tril", in_dtype=x.dtype, out_dtype=out.dtype)
+        ph.assert_shape("tril", out_shape=out.shape, expected=x.shape)
+        expected = _triangular_expected(x, k=k, upper=False)
+        ph.assert_array_elements("tril", out=out, expected=expected, kw={"k": k})
+    except Exception as exc:
+        ph.add_note(exc, repro_snippet)
+        raise
+
+
+@given(x=hh.arrays(dtype=hh.numeric_dtypes, shape=hh.matrix_shapes()), data=st.data())
+def test_triu(x, data):
+    n, m = x.shape[-2:]
+    k = data.draw(st.integers(min_value=-max(n, m, 1), max_value=max(n, m, 1)), label="k")
+    repro_snippet = ph.format_snippet(f"xp.triu({x!r}, k={k!r})")
+    try:
+        out = xp.triu(x, k=k)
+        ph.assert_dtype("triu", in_dtype=x.dtype, out_dtype=out.dtype)
+        ph.assert_shape("triu", out_shape=out.shape, expected=x.shape)
+        expected = _triangular_expected(x, k=k, upper=True)
+        ph.assert_array_elements("triu", out=out, expected=expected, kw={"k": k})
+    except Exception as exc:
+        ph.add_note(exc, repro_snippet)
+        raise
+
+
 default_unsafe_dtypes = [xp.uint64]
 if dh.default_int == xp.int32:
     default_unsafe_dtypes.extend([xp.uint32, xp.int64])


### PR DESCRIPTION
See: #441 (That PR has been split and tests for tril and triu are added here)

Towards: #439 