### PR TITLE
MAINT: test_eye: limit the range of k

### DIFF
--- a/array_api_tests/test_creation_functions.py
+++ b/array_api_tests/test_creation_functions.py
@@ -365,7 +365,7 @@ def test_empty_like(x, kw):
     n_rows=hh.sqrt_sizes,
     n_cols=st.none() | hh.sqrt_sizes,
     kw=hh.kwargs(
-        k=st.integers(),
+        k=st.integers(min_value=-hh.SQRT_MAX_ARRAY_SIZE, max_value=hh.SQRT_MAX_ARRAY_SIZE),
         dtype=hh.numeric_dtypes,
     ),
 )


### PR DESCRIPTION
Limit the range of the `k` variable in testing `eye(n_rows, n_cols, k)` to avoid using completely bogus values. Caught in
https://github.com/data-apis/array-api-compat/issues/452: 
>  Large valid diagonal offsets such as k=2147483648 overflow or fail MLX’s argument binding.