### PR TITLE
CI: use array_api_strict main branch for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install array-api-strict
+        python -m pip install https://github.com/data-apis/array-api-strict.git
         python -m pip install -r requirements.txt
+        python -c'import array_api_strict; print(array_api_strict.__file__)'
     - name: Run the test suite
       env:
         ARRAY_API_TESTS_MODULE: array_api_strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install https://github.com/data-apis/array-api-strict.git
+        python -m pip install git+https://github.com/data-apis/array-api-strict.git@main
         python -m pip install -r requirements.txt
         python -c'import array_api_strict; print(array_api_strict.__file__)'
     - name: Run the test suite


### PR DESCRIPTION
On CI, use the `array_api_strict` main branch instead of a released version. That way, when something is fixed in -strict, 
we don't have to wait for a release to unblock the CI here.