### PR TITLE
fix: avoid dtype comparison for None report metadata

### DIFF
--- a/meta_tests/test_reporting.py
+++ b/meta_tests/test_reporting.py
@@ -1,0 +1,16 @@
+from array_api_tests.dtype_helpers import EqualityMapping
+import reporting
+
+
+class MLXDtype:
+    def __eq__(self, other):
+        if other is None:
+            raise TypeError("MLX dtype equality does not support None")
+        return self is other
+
+
+def test_to_json_serializable_none_does_not_compare_to_dtypes(monkeypatch):
+    dtype = MLXDtype()
+    monkeypatch.setattr(reporting, "dtype_to_name", EqualityMapping([(dtype, "float16")]))
+
+    assert reporting.to_json_serializable(None) is None

--- a/reporting.py
+++ b/reporting.py
@@ -17,7 +17,7 @@ except ImportError:
     raise ImportError("pytest-json-report is required to run the array API tests")
 
 def to_json_serializable(o):
-    if o in dtype_to_name:
+    if o is not None and o in dtype_to_name:
         return dtype_to_name[o]
     if isinstance(o, (BuiltinFunctionType, FunctionType, type)):
         return o.__name__


### PR DESCRIPTION
## Summary

- avoid comparing `None` with array-library dtype objects before looking them up in `dtype_to_name`
- add a regression test using an MLX-like dtype whose equality operation rejects `None`

Closes #447

## Validation

- `ARRAY_API_TESTS_MODULE=numpy PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q -p pytest_jsonreport.plugin meta_tests/test_reporting.py` passed: 1 test
- `ARRAY_API_TESTS_MODULE=numpy PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q -p pytest_jsonreport.plugin meta_tests/test_utils.py` passed: 30 tests
- `python -m compileall -q reporting.py meta_tests/test_reporting.py` passed
- `git diff --check` passed

The full suite was not run. The focused commands disable unrelated globally installed pytest plugins and load the repository's JSON-report plugin explicitly.