### PR TITLE
BUG: use Python integers for repeat slice bounds

### DIFF
--- a/array_api_tests/test_manipulation_functions.py
+++ b/array_api_tests/test_manipulation_functions.py
@@ -410,10 +410,11 @@ def test_repeat(x, kw, data):
             out_slice = out[idx]
             start = 0
             for i, count in enumerate(repeats_array):
+                count = int(count)
                 end = start + count
                 x_slice_i = dh.get_scalar_type(x.dtype)((x_slice[i]))
                 ph.assert_array_elements("repeat", out=out_slice[start:end],
-                                         expected=xp.full((int(count),), x_slice_i, dtype=x.dtype),
+                                         expected=xp.full((count,), x_slice_i, dtype=x.dtype),
                                          kw=kw)
                 start = end
 


### PR DESCRIPTION
## Summary

Closes #450. `test_repeat` now converts each array-valued repeat count to a Python integer before computing slice bounds. This keeps the value check compatible with libraries such as MLX that do not accept 0D arrays as slice indices.

## Validation

- Reproduced the failure with an integer-convertible scalar that does not implement `__index__`, then confirmed the same path passes after the change
- `ARRAY_API_TESTS_MODULE=array_api_strict .venv/bin/python -m pytest -q array_api_tests/test_manipulation_functions.py::test_repeat --max-examples=1000 --disable-deadline`
- `ARRAY_API_TESTS_MODULE=array_api_strict .venv/bin/python -m pytest -q meta_tests` (70 passed, 1 skipped)
- `.venv/bin/pre-commit run --all-files`

The full manipulation test file also surfaced an unrelated `test_reshape` failure for an empty array with `copy=False`; the changed `test_repeat` passes independently.
