### PR TITLE
Fix matrix transpose reference construction

### DIFF
--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -516,10 +516,14 @@ def test_matrix_rank(x, kw):
 def _test_matrix_transpose(namespace, x):
     matrix_transpose = namespace.matrix_transpose
     res = matrix_transpose(x)
-    true_val = lambda a: _array_module.asarray([[a[i, j] for i in
-                                                range(a.shape[0])] for j in
-                                                range(a.shape[1])],
-                                               dtype=a.dtype)
+    def true_val(a):
+        expected = _array_module.empty((a.shape[1], a.shape[0]),
+                                       dtype=a.dtype, device=a.device)
+        for i in range(a.shape[0]):
+            for j in range(a.shape[1]):
+                expected[j, i] = a[i, j]
+        return expected
+
     shape = list(x.shape)
     shape[-1], shape[-2] = shape[-2], shape[-1]
     shape = tuple(shape)

--- a/array_api_tests/test_linalg.py
+++ b/array_api_tests/test_linalg.py
@@ -517,12 +517,10 @@ def _test_matrix_transpose(namespace, x):
     matrix_transpose = namespace.matrix_transpose
     res = matrix_transpose(x)
     def true_val(a):
-        expected = _array_module.empty((a.shape[1], a.shape[0]),
-                                       dtype=a.dtype, device=a.device)
-        for i in range(a.shape[0]):
-            for j in range(a.shape[1]):
-                expected[j, i] = a[i, j]
-        return expected
+        if 0 in a.shape:
+            return xp.empty((a.shape[1], a.shape[0]),
+                            dtype=a.dtype, device=a.device)
+        return xp.stack([a[i, :] for i in range(a.shape[0])], axis=1)
 
     shape = list(x.shape)
     shape[-1], shape[-2] = shape[-2], shape[-1]

--- a/meta_tests/test_linalg.py
+++ b/meta_tests/test_linalg.py
@@ -5,6 +5,31 @@ from hypothesis import given
 from array_api_tests .hypothesis_helpers import symmetric_matrices
 from array_api_tests import array_helpers as ah
 from array_api_tests import _array_module as xp
+from array_api_tests.test_linalg import _test_matrix_transpose
+
+
+@pytest.mark.parametrize('shape', [(2, 3), (2, 2, 3), (0, 3), (3, 0), (0, 0)])
+def test_matrix_transpose_without_nested_arrays(monkeypatch, shape):
+    size = 1
+    for dim in shape:
+        size *= dim
+    x = xp.reshape(xp.arange(size, dtype=xp.int64), shape)
+    original_asarray = xp.asarray
+
+    def asarray(obj, **kwargs):
+        def check_sequence(value):
+            if isinstance(value, (list, tuple)):
+                for item in value:
+                    check_sequence(item)
+            else:
+                assert isinstance(value, (bool, int, float, complex))
+
+        if isinstance(obj, (list, tuple)):
+            check_sequence(obj)
+        return original_asarray(obj, **kwargs)
+
+    monkeypatch.setattr(xp, 'asarray', asarray)
+    _test_matrix_transpose(xp, x)
 
 @pytest.mark.xp_extension('linalg')
 @given(x=symmetric_matrices(finite=True))


### PR DESCRIPTION
`_test_matrix_transpose` constructs its expected result by passing nested lists of zero-dimensional arrays to `asarray`, although the standard only requires nested sequences of Python scalars. Construct the expected transpose by stacking the input rows along axis 1. For empty matrices, allocate the transposed shape explicitly with the input dtype and device, since `stack` requires a nonempty sequence. This also preserves both dimensions for empty matrices.

Add regression coverage that rejects non-Python-scalar sequence elements in `asarray`, covering rectangular matrices, stacks, and empty dimensions.

Validation with array-api-strict 2.6.1 on Python 3.14:
- Confirmed the new regression cases fail before the fix (nested-array inputs and lost empty dimensions).
- Both matrix transpose tests and all linalg meta-tests pass (8 passed).
- Flake8 `--select F` on both changed files and `git diff --check` pass.

Fixes #461.
